### PR TITLE
chore: pin orml to specific revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ff35b701f3914bdb8fad3368d822c766ef2858b2583198e41639b936f09d3f"
+checksum = "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
@@ -975,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 dependencies = [
  "jobserver",
 ]
@@ -1706,9 +1706,9 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a94feec3d2ba66c0b6621bca8bc6f68415b1e5c69af3586fdd0af9fd9f29b17"
+checksum = "d3920ab0ba823e4fe0fe4c358f105a7e36643f2155f409b13df03e67965d296f"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -1949,9 +1949,9 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0465971a8cc1fa2455c8465aaa377131e1f1cf4983280f474a13e68793aa770c"
+checksum = "e5b36e6f2295f393f44894c6031f67df4d185b984cd54d08f768ce678007efcd"
 dependencies = [
  "serde",
 ]
@@ -2622,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -3565,9 +3565,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "libloading"
@@ -4207,9 +4207,9 @@ checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memmap2"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397d1a6d6d0563c0f5462bbdae662cf6c784edf5e828e40c7257f85d82bf56dd"
+checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
 dependencies = [
  "libc",
 ]
@@ -4679,7 +4679,7 @@ dependencies = [
 [[package]]
 name = "orml-currencies"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=master#cfe19133f02dac83dd6652473f9981852c02493f"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=11191abe385c9e74a6f179fc1df0e37c5163e9fe#11191abe385c9e74a6f179fc1df0e37c5163e9fe"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4695,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "orml-tokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=master#cfe19133f02dac83dd6652473f9981852c02493f"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=11191abe385c9e74a6f179fc1df0e37c5163e9fe#11191abe385c9e74a6f179fc1df0e37c5163e9fe"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4709,7 +4709,7 @@ dependencies = [
 [[package]]
 name = "orml-traits"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=master#cfe19133f02dac83dd6652473f9981852c02493f"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=11191abe385c9e74a6f179fc1df0e37c5163e9fe#11191abe385c9e74a6f179fc1df0e37c5163e9fe"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -4725,7 +4725,7 @@ dependencies = [
 [[package]]
 name = "orml-utilities"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?branch=master#cfe19133f02dac83dd6652473f9981852c02493f"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=11191abe385c9e74a6f179fc1df0e37c5163e9fe#11191abe385c9e74a6f179fc1df0e37c5163e9fe"
 dependencies = [
  "frame-support",
  "parity-scale-codec 2.1.1",
@@ -4746,8 +4746,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-registry"
-version = "3.0.1"
-source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#f57debc4c2f8dbb174e46dd9f351e07b8314b930"
+version = "3.1.0"
+source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#694cce69ee44890dcbd05c9ef1cd83079e3ce1ac"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4938,8 +4938,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-exchange"
-version = "3.0.1"
-source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#f57debc4c2f8dbb174e46dd9f351e07b8314b930"
+version = "3.1.0"
+source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#694cce69ee44890dcbd05c9ef1cd83079e3ce1ac"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4959,8 +4959,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-exchange-benchmarking"
-version = "3.0.1"
-source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#f57debc4c2f8dbb174e46dd9f351e07b8314b930"
+version = "3.1.0"
+source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#694cce69ee44890dcbd05c9ef1cd83079e3ce1ac"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4981,8 +4981,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-faucet"
-version = "3.0.1"
-source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#f57debc4c2f8dbb174e46dd9f351e07b8314b930"
+version = "3.1.0"
+source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#694cce69ee44890dcbd05c9ef1cd83079e3ce1ac"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5149,8 +5149,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-multi-payment-benchmarking"
-version = "3.0.2"
-source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#f57debc4c2f8dbb174e46dd9f351e07b8314b930"
+version = "3.1.0"
+source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#694cce69ee44890dcbd05c9ef1cd83079e3ce1ac"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5393,8 +5393,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-multi-payment"
-version = "3.0.2"
-source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#f57debc4c2f8dbb174e46dd9f351e07b8314b930"
+version = "3.1.0"
+source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#694cce69ee44890dcbd05c9ef1cd83079e3ce1ac"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5515,8 +5515,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xyk"
-version = "1.0.0"
-source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#f57debc4c2f8dbb174e46dd9f351e07b8314b930"
+version = "1.1.0"
+source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#694cce69ee44890dcbd05c9ef1cd83079e3ce1ac"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5539,7 +5539,7 @@ dependencies = [
 [[package]]
 name = "pallet-xyk-rpc"
 version = "1.0.0"
-source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#f57debc4c2f8dbb174e46dd9f351e07b8314b930"
+source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#694cce69ee44890dcbd05c9ef1cd83079e3ce1ac"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5557,7 +5557,7 @@ dependencies = [
 [[package]]
 name = "pallet-xyk-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#f57debc4c2f8dbb174e46dd9f351e07b8314b930"
+source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#694cce69ee44890dcbd05c9ef1cd83079e3ce1ac"
 dependencies = [
  "parity-scale-codec 2.1.1",
  "serde",
@@ -7098,8 +7098,8 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "3.0.0"
-source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#f57debc4c2f8dbb174e46dd9f351e07b8314b930"
+version = "3.1.0"
+source = "git+https://github.com/galacticcouncil/HydraDX-node?branch=master#694cce69ee44890dcbd05c9ef1cd83079e3ce1ac"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7107,7 +7107,6 @@ dependencies = [
  "primitive-types 0.8.0",
  "serde",
  "sp-std",
- "substrate-fixed",
  "substrate-wasm-builder 3.0.0",
 ]
 
@@ -7168,9 +7167,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -7242,9 +7241,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abf49e5417290756acfd26501536358560c4a5cc4a0934d390939acb3e7083a"
+checksum = "21ff0279b4a85e576b97e4a21d13e437ebcd56612706cde5d3f0d5c9399490c0"
 dependencies = [
  "cc",
 ]
@@ -7403,7 +7402,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -7503,7 +7502,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "redox_syscall 0.2.8",
 ]
 
@@ -10097,15 +10096,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-fixed"
-version = "0.5.6"
-source = "git+https://github.com/encointer/substrate-fixed#b33d186888c60f38adafcfc0ec3a21aab263aef1"
-dependencies = [
- "parity-scale-codec 2.1.1",
- "typenum",
-]
-
-[[package]]
 name = "substrate-frame-rpc-system"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.1#3f110196163b5ec03bac5ee188d60bedf3ebd91d"
@@ -10352,18 +10342,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11084,9 +11074,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,13 +70,13 @@ substrate-test-runtime-client = { git = 'https://github.com/paritytech/substrate
 pallet-transaction-payment = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.1" }
 
 # ORML dependencies
-orml-currencies = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', branch = 'master' }
-orml-tokens = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', branch = 'master' }
-#orml-unknown-tokens = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', branch = 'master' }
-orml-traits = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', branch = 'master' }
-orml-utilities = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', branch = 'master' }
-#orml-xtokens= { git = 'https://github.com/open-web3-stack/open-runtime-module-library', branch = 'master' }
-#orml-xcm-support = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', branch = 'master' }
+orml-currencies = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', rev = '11191abe385c9e74a6f179fc1df0e37c5163e9fe' }
+orml-tokens = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', rev = '11191abe385c9e74a6f179fc1df0e37c5163e9fe' }
+#orml-unknown-tokens = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', rev = '11191abe385c9e74a6f179fc1df0e37c5163e9fe' }
+orml-traits = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', rev = '11191abe385c9e74a6f179fc1df0e37c5163e9fe' }
+orml-utilities = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', rev = '11191abe385c9e74a6f179fc1df0e37c5163e9fe' }
+#orml-xtokens= { git = 'https://github.com/open-web3-stack/open-runtime-module-library', rev = '11191abe385c9e74a6f179fc1df0e37c5163e9fe' }
+#orml-xcm-support = { git = 'https://github.com/open-web3-stack/open-runtime-module-library', rev = '11191abe385c9e74a6f179fc1df0e37c5163e9fe' }
 
 # Polkadot dependencies
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.1" }


### PR DESCRIPTION
## Description
Basilisk uses orml dependencies from master branch. Since there was a change to use more recent substrate version  from different branch ( polkadot-v0.9.2) - doing any cargo update will result in having 2 different versions of substrate. 

Basilisk is currently built with substrate from branch polkadot-v0.9.1

Therefore, this PR pins the orml to specific revision where the same version of substrate is used.