### PR TITLE
refactor(nft): remove unnecessary currencybalance from pallet config

### DIFF
--- a/pallets/nft/src/benchmarking.rs
+++ b/pallets/nft/src/benchmarking.rs
@@ -10,7 +10,9 @@ const EMOTE: &str = "RMRK::EMOTE::RMRK1.0.0::0aff6865bed3a66b-VALHELLO-POTION_HE
 
 fn create_account<T: Config>(name: &'static str, index: u32) -> T::AccountId {
 	let caller: T::AccountId = account(name, index, SEED);
-	T::Currency::deposit_creating(&caller, T::CurrencyBalance::from(1_000_000_u128).into());
+
+	let amount: BalanceOf<T> = 1_000_000_u32.into();
+	T::Currency::deposit_creating(&caller, amount);
 	caller
 }
 
@@ -20,9 +22,12 @@ benchmarks! {
 		let class_metadata = "just a token class".as_bytes().to_vec();
 		let class_data = ClassData { is_pool:true };
 		let class_id = orml_nft::Pallet::<T>::next_class_id();
-	}: _(RawOrigin::Signed(caller.clone()), class_metadata, class_data, T::CurrencyBalance::from(666_u128).into())
+
+		let price: BalanceOf<T> = 666_u32.into();
+
+	}: _(RawOrigin::Signed(caller.clone()), class_metadata, class_data, price)
 	verify {
-		assert_eq!(ClassItemPrice::<T>::get(class_id), T::CurrencyBalance::from(666_u128).into());
+		assert_eq!(ClassItemPrice::<T>::get(class_id), price);
 	}
 
 	mint {

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -72,9 +72,6 @@ pub mod pallet {
 		type Currency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		type WeightInfo: WeightInfo;
-		// This type is needed to convert from Currency to Balance
-		type CurrencyBalance: From<Balance>
-			+ Into<<Self::Currency as Currency<<Self as frame_system::Config>::AccountId>>::Balance>;
 		#[pallet::constant]
 		type ClassBondAmount: Get<BalanceOf<Self>>;
 		#[pallet::constant]

--- a/pallets/nft/src/mock.rs
+++ b/pallets/nft/src/mock.rs
@@ -42,7 +42,6 @@ impl pallet_nft::Config for Test {
 	type Currency = Balances;
 	type Event = Event;
 	type WeightInfo = pallet_nft::weights::BasiliskWeight<Test>;
-	type CurrencyBalance = Balance;
 	type ClassBondAmount = ClassBondAmount;
 	type ClassBondDuration = ClassBondDuration;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -404,7 +404,6 @@ impl pallet_nft::Config for Runtime {
 	type Currency = Balances;
 	type Event = Event;
 	type WeightInfo = pallet_nft::weights::BasiliskWeight<Runtime>;
-	type CurrencyBalance = Balance;
 	type ClassBondAmount = ClassBondAmount;
 	type ClassBondDuration = ClassBondDuration;
 }


### PR DESCRIPTION
## Description
Removed `CurrencyBalance` from pallet config as it is not necessary ( used only in benchmarks).

