### PR TITLE
chore: update rust-toolchain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: git describe --tags --abbrev=0 --always
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
           override: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,8 +80,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-06-01
-          target: wasm32-unknown-unknown
           override: true
           default: true
       - name: Install tarpaulin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,8 @@ jobs:
         uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
+          toolchain: nightly-2021-06-01
+          target: wasm32-unknown-unknown
           override: true
           default: true
       - name: Install tarpaulin

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-03-01"
+channel = "nightly-2021-06-01"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
Toolchain updated to more recent version.

Reasons:
- same as in HydraDX
- same as in GH workflow 
- no longer possible to compile some stuff with the older one.