### PR TITLE
fix(xyk): create_pool respects min liquidity limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "basilisk-runtime"
-version = "10.0.0"
+version = "11.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -5888,7 +5888,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xyk"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -6,7 +6,7 @@ homepage = 'https://github.com/galacticcouncil/basilisk-node'
 license = 'Apache 2.0'
 name = 'pallet-xyk'
 repository = 'https://github.com/galacticcouncil/basilisk-node'
-version = '1.2.0'
+version = '1.3.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/pallets/xyk/src/lib.rs
+++ b/pallets/xyk/src/lib.rs
@@ -240,6 +240,8 @@ pub mod pallet {
 				.checked_mul_int(amount)
 				.ok_or(Error::<T>::CreatePoolAssetAmountInvalid)?;
 
+			ensure!(asset_b_amount >= MIN_POOL_LIQUIDITY, Error::<T>::InsufficientLiquidity);
+
 			let shares_added = if asset_a < asset_b { amount } else { asset_b_amount };
 
 			ensure!(

--- a/pallets/xyk/src/tests.rs
+++ b/pallets/xyk/src/tests.rs
@@ -1129,6 +1129,11 @@ fn create_pool_with_insufficient_liquidity_should_not_work() {
 		);
 
 		assert_noop!(
+			XYK::create_pool(Origin::signed(ALICE), ACA, HDX, 5000, Price::from_float(0.1f64)),
+			Error::<Test>::InsufficientLiquidity
+		);
+
+		assert_noop!(
 			XYK::create_pool(Origin::signed(ALICE), ACA, HDX, 1000, Price::from(0)),
 			Error::<Test>::ZeroInitialPrice
 		);

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://github.com/galacticcouncil/Basilisk-node'
 license = 'Apache 2.0'
 name = 'basilisk-runtime'
 repository = 'https://github.com/galacticcouncil/Basilisk-node'
-version = '10.0.0'
+version = '11.0.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("basilisk"),
 	impl_name: create_runtime_str!("basilisk"),
 	authoring_version: 1,
-	spec_version: 10,
+	spec_version: 11,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
## Description
Create pool only if both amounts are greater than `MIN_POOL_LIQUIDITY`.

