### PR TITLE
ci: restrict gh workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ on:
       - master
   workflow_dispatch:
   pull_request:
+    paths:
+      - '**.rs'
 
 jobs:
   pop-runner-instance:


### PR DESCRIPTION

Added change to run gh workflows only if there is a changes in any rust file. 

