### PR TITLE
feat: balance check as signed extension

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,3 +12,4 @@ coverage:
     patch: 
       default:
         threshold: 5%
+        informational: true

--- a/pallets/transaction-multi-payment/src/lib.rs
+++ b/pallets/transaction-multi-payment/src/lib.rs
@@ -531,7 +531,7 @@ pub struct CurrencyBalanceCheck<T: Config + Send + Sync>(PhantomData<T>);
 
 impl<T: Config + Send + Sync> sp_std::fmt::Debug for CurrencyBalanceCheck<T> {
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		write!(f, "ValidateClaim")
+		write!(f, "CurrencyBalanceCheck")
 	}
 }
 

--- a/pallets/transaction-multi-payment/src/lib.rs
+++ b/pallets/transaction-multi-payment/src/lib.rs
@@ -54,6 +54,11 @@ use primitives::asset::AssetPair;
 use primitives::traits::AMM;
 use primitives::{Amount, AssetId, Balance, CORE_ASSET_ID};
 
+use codec::{Decode, Encode};
+use frame_support::sp_runtime::traits::SignedExtension;
+use frame_support::sp_runtime::transaction_validity::{TransactionValidity, ValidTransaction};
+use frame_support::traits::IsSubType;
+
 type NegativeImbalanceOf<C, T> = <C as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance;
 // Re-export pallet items so that they can be accessed from the crate namespace.
 pub use pallet::*;
@@ -376,10 +381,12 @@ impl<T: Config> Pallet<T> {
 		let adjusted_weight_fee = Self::weight_to_fee(T::WeightInfo::set_currency());
 		let fee = base_fee.saturating_add(adjusted_weight_fee);
 
-        let result = Self::swap(who, fee)?;
-        match result {
+		let result = Self::swap(who, fee)?;
+		match result {
 			PaymentSwapResult::Transferred => Ok(()),
-			PaymentSwapResult::Native | PaymentSwapResult::Swapped => T::MultiCurrency::withdraw(CORE_ASSET_ID, who, fee),
+			PaymentSwapResult::Native | PaymentSwapResult::Swapped => {
+				T::MultiCurrency::withdraw(CORE_ASSET_ID, who, fee)
+			}
 		}
 	}
 
@@ -388,6 +395,13 @@ impl<T: Config> Pallet<T> {
 		// `Bounded` maximum of its data type, which is not desired.
 		let capped_weight: Weight = weight.min(T::BlockWeights::get().max_block);
 		<T as Config>::WeightToFee::calc(&capped_weight)
+	}
+
+	fn check_balance(account: &T::AccountId, currency: AssetId) -> Result<(), Error<T>> {
+		if T::MultiCurrency::free_balance(currency, account) == Balance::zero() {
+			return Err(Error::<T>::ZeroBalance.into());
+		};
+		Ok(())
 	}
 }
 
@@ -508,5 +522,53 @@ where
 			OU::on_unbalanceds(Some(imbalances.0).into_iter().chain(Some(imbalances.1)));
 		}
 		Ok(())
+	}
+}
+
+/// Signed extension that checks for the `set_currency` call and in that case, it checks the account balance
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+pub struct CurrencyBalanceCheck<T: Config + Send + Sync>(PhantomData<T>);
+
+impl<T: Config + Send + Sync> sp_std::fmt::Debug for CurrencyBalanceCheck<T> {
+	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		write!(f, "ValidateClaim")
+	}
+}
+
+impl<T: Config + Send + Sync> SignedExtension for CurrencyBalanceCheck<T>
+where
+	<T as frame_system::Config>::Call: IsSubType<Call<T>>,
+{
+	const IDENTIFIER: &'static str = "CurrencyBalanceCheck";
+	type AccountId = T::AccountId;
+	type Call = <T as frame_system::Config>::Call;
+	type AdditionalSigned = ();
+	type Pre = ();
+
+	fn additional_signed(&self) -> sp_std::result::Result<(), TransactionValidityError> {
+		Ok(())
+	}
+
+	fn validate(
+		&self,
+		who: &Self::AccountId,
+		call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
+	) -> TransactionValidity {
+		match call.is_sub_type() {
+			Some(Call::set_currency(currency)) => match Pallet::<T>::check_balance(who, *currency) {
+				Ok(_) => Ok(ValidTransaction::default()),
+				Err(error) => InvalidTransaction::Custom(error.as_u8()).into(),
+			},
+			_ => Ok(Default::default()),
+		}
+	}
+}
+
+impl<T: Config + Send + Sync> CurrencyBalanceCheck<T> {
+	#[cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
+	pub fn new() -> Self {
+		Self(sp_std::marker::PhantomData)
 	}
 }

--- a/pallets/transaction-multi-payment/src/tests.rs
+++ b/pallets/transaction-multi-payment/src/tests.rs
@@ -20,10 +20,13 @@ use frame_support::{assert_noop, assert_ok};
 use pallet_transaction_payment::ChargeTransactionPayment;
 use sp_runtime::traits::SignedExtension;
 
+use crate::CurrencyBalanceCheck;
+use frame_support::sp_runtime::transaction_validity::{InvalidTransaction, ValidTransaction};
 use frame_support::weights::DispatchInfo;
 use orml_traits::MultiCurrency;
 use pallet_balances::Call as BalancesCall;
 use primitives::Price;
+use sp_std::marker::PhantomData;
 
 const CALL: &<Test as frame_system::Config>::Call = &Call::Balances(BalancesCall::transfer(2, 69));
 
@@ -431,4 +434,37 @@ fn fee_payment_non_native_insufficient_balance_with_no_pool() {
 
 			assert_eq!(Tokens::free_balance(SUPPORTED_CURRENCY_WITH_BALANCE, &CHARLIE), 457);
 		});
+}
+
+#[test]
+fn check_balance_extension_works() {
+	const CHARLIE: AccountId = 5;
+
+	ExtBuilder::default()
+		.account_tokens(CHARLIE, SUPPORTED_CURRENCY_WITH_BALANCE, 1000)
+		.build()
+		.execute_with(|| {
+			let call = <crate::Call<Test>>::set_currency(SUPPORTED_CURRENCY_WITH_BALANCE).into();
+			let info = DispatchInfo::default();
+
+			assert_eq!(
+				CurrencyBalanceCheck::<Test>(PhantomData).validate(&CHARLIE, &call, &info, 150),
+				Ok(ValidTransaction::default())
+			);
+		});
+}
+
+#[test]
+fn check_balance_extension_fails() {
+	const NOT_CHARLIE: AccountId = 6;
+
+	ExtBuilder::default().build().execute_with(|| {
+		let call = <crate::Call<Test>>::set_currency(SUPPORTED_CURRENCY_WITH_BALANCE).into();
+		let info = DispatchInfo::default();
+
+		assert_eq!(
+			CurrencyBalanceCheck::<Test>(PhantomData).validate(&NOT_CHARLIE, &call, &info, 150),
+			InvalidTransaction::Custom(Error::<Test>::ZeroBalance.as_u8()).into()
+		);
+	});
 }

--- a/pallets/transaction-multi-payment/src/tests.rs
+++ b/pallets/transaction-multi-payment/src/tests.rs
@@ -451,6 +451,13 @@ fn check_balance_extension_works() {
 				CurrencyBalanceCheck::<Test>(PhantomData).validate(&CHARLIE, &call, &info, 150),
 				Ok(ValidTransaction::default())
 			);
+
+			let call = <crate::Call<Test>>::add_currency(SUPPORTED_CURRENCY_WITH_BALANCE, Price::from(1)).into();
+
+			assert_eq!(
+				CurrencyBalanceCheck::<Test>(PhantomData).validate(&CHARLIE, &call, &info, 150),
+				Ok(ValidTransaction::default())
+			);
 		});
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -873,6 +873,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	pallet_transaction_multi_payment::CurrencyBalanceCheck<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;


### PR DESCRIPTION
Added signed extension for multi-payment pallet to check account balance when set_currency call is executed.

Balance must  > 0 atm.