### PR TITLE
fix(vesting): fix benchmarking

### DIFF
--- a/node/res/basilisk-vesting-lbp-test.json
+++ b/node/res/basilisk-vesting-lbp-test.json
@@ -1,5 +1,4 @@
 [
 	[ "bXmPf7DcVmFuHEmzH3UX8t6AUkfNQW8pnTeXGhFhqbfngjAak", 5, 1, 30, 100000000000 ],
-	[ "bXjpVq9SMdXuP5mVmcYZC8kFWepMX3bRSxpNwdtaAXgsSxPwd", 5, 1, 30, 200000000000 ],
-	[ "bXjs9uKaPxXo1iNuS9L9X8QhoUx2u2uJJPbeHAtsGp63yFWSU", 5, 1, 30, 300000000000 ]
+	[ "bXjpVq9SMdXuP5mVmcYZC8kFWepMX3bRSxpNwdtaAXgsSxPwd", 5, 1, 30, 200000000000 ]
 ]


### PR DESCRIPTION
## Description
Benchmarking fails because VestingConfig in [parachain_development_config](https://github.com/galacticcouncil/Basilisk-node/blob/ef5a731fdbc77e0a076cc0709ea532f854a8f1c7/node/src/chain_spec.rs#L291) contains non-endowed account (Charlie). The issue is fixed by removing the account from `node/res/basilisk-vesting-lbp-test.json` file.
An alternative solution is to use different account( e.g. Alice//stash or Bob//stash).