### PR TITLE
feat: Added an extra node to the rococo-local config

### DIFF
--- a/rococo-local/config.json
+++ b/rococo-local/config.json
@@ -48,8 +48,8 @@
         },
         {
           "wsPort": 9989,
-          "port": 31200,
-          "flags": ["--alice", "--rpc-cors=all", "--", "--execution=wasm"]
+          "port": 31201,
+          "flags": ["--bob", "--rpc-cors=all", "--", "--execution=wasm"]
         }
       ]
     }

--- a/rococo-local/config.json
+++ b/rococo-local/config.json
@@ -44,7 +44,12 @@
         {
           "wsPort": 9988,
           "port": 31200,
-          "flags": ["--alice","--", "--execution=wasm"]
+          "flags": ["--alice", "--rpc-cors=all", "--", "--execution=wasm"]
+        },
+        {
+          "wsPort": 9989,
+          "port": 31200,
+          "flags": ["--alice", "--rpc-cors=all", "--", "--execution=wasm"]
         }
       ]
     }


### PR DESCRIPTION
Added an extra parachain node to the rococo-local `config.json`, otherwise the subsquid indexer would not connect normally or blocks would not be produced on the parachain.

## Description
Added an extra parachain node to the rococo-local testnet config with additional cli options.

## Related Issue
Implements: #164

## How Has This Been Tested?
You can test that the rococo-local setup still works by running `polkadot-launch config.json`

