### PR TITLE
fix: update orml-tokens whitelist accounts

### DIFF
--- a/pallets/duster/src/lib.rs
+++ b/pallets/duster/src/lib.rs
@@ -285,13 +285,16 @@ impl<T: Config> Pallet<T> {
 
 use orml_traits::OnDust;
 
+use sp_std::marker::PhantomData;
+pub struct DusterWhitelist<T>(PhantomData<T>);
+
 impl<T: Config> OnDust<T::AccountId, T::CurrencyId, T::Balance> for Pallet<T> {
 	fn on_dust(who: &T::AccountId, currency_id: T::CurrencyId, amount: T::Balance) {
 		let _ = Self::transfer_dust(who, &Self::dust_dest_account(), currency_id, amount);
 	}
 }
 
-impl<T: Config> Contains<T::AccountId> for Pallet<T> {
+impl<T: Config> Contains<T::AccountId> for DusterWhitelist<T> {
 	fn contains(t: &T::AccountId) -> bool {
 		AccountBlacklist::<T>::contains_key(t)
 	}

--- a/pallets/duster/src/lib.rs
+++ b/pallets/duster/src/lib.rs
@@ -27,7 +27,7 @@ mod tests;
 mod benchmarking;
 pub mod weights;
 
-use frame_support::{dispatch::DispatchResult, traits::Get};
+use frame_support::{dispatch::DispatchResult, traits::Contains, traits::Get};
 
 use orml_traits::{
 	arithmetic::{Signed, SimpleArithmetic},
@@ -288,5 +288,11 @@ use orml_traits::OnDust;
 impl<T: Config> OnDust<T::AccountId, T::CurrencyId, T::Balance> for Pallet<T> {
 	fn on_dust(who: &T::AccountId, currency_id: T::CurrencyId, amount: T::Balance) {
 		let _ = Self::transfer_dust(who, &Self::dust_dest_account(), currency_id, amount);
+	}
+}
+
+impl<T: Config> Contains<T::AccountId> for Pallet<T> {
+	fn contains(t: &T::AccountId) -> bool {
+		AccountBlacklist::<T>::contains_key(t)
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -364,7 +364,7 @@ impl orml_tokens::Config for Runtime {
 	type ExistentialDeposits = AssetRegistry;
 	type OnDust = Duster;
 	type MaxLocks = MaxLocks;
-	type DustRemovalWhitelist = Duster;
+	type DustRemovalWhitelist = pallet_duster::DusterWhitelist<Runtime>;
 }
 
 impl orml_currencies::Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -36,7 +36,7 @@ use sp_version::RuntimeVersion;
 pub use frame_support::{
 	construct_runtime, match_type, parameter_types,
 	traits::{
-		Contains, EnsureOrigin, Get, KeyOwnerProofSystem, LockIdentifier, Nothing, Randomness, U128CurrencyToVote,
+		Contains, EnsureOrigin, Get, KeyOwnerProofSystem, LockIdentifier, Randomness, U128CurrencyToVote,
 	},
 	weights::{
 		constants::{BlockExecutionWeight, RocksDbWeight, WEIGHT_PER_SECOND},
@@ -364,7 +364,7 @@ impl orml_tokens::Config for Runtime {
 	type ExistentialDeposits = AssetRegistry;
 	type OnDust = Duster;
 	type MaxLocks = MaxLocks;
-	type DustRemovalWhitelist = Nothing;
+	type DustRemovalWhitelist = Duster;
 }
 
 impl orml_currencies::Config for Runtime {


### PR DESCRIPTION
Updated orml-tokens list of non-dustable accounts. 

It actually uses the duster list as it is duster who handles all the details regarding dust and dusting.

Currenly, on Basilisk - there is only treasury account. 