### PR TITLE
chore: makefile linking fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 build:
 	cargo build --release
-	ln -s $(CURDIR)/target/release/basilisk $(CURDIR)/target/release/testing-basilisk
+	ln -sf $(CURDIR)/target/release/basilisk $(CURDIR)/target/release/testing-basilisk
 
 .PHONY: check
 check:


### PR DESCRIPTION
`make build` throws error when the symbolic link already exists.
This fix forces the `ln` command to replace the existing link.
