### PR TITLE
feat: disallow collating with benchmarking runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "basilisk"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "basilisk-runtime",
  "common-runtime",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilisk"
-version = "4.0.0"
+version = "4.1.0"
 description = "Basilisk node"
 authors = ["GalacticCouncil"]
 edition = "2018"

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -337,6 +337,10 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(&cli.run.base.normalize())?;
 
 			runner.run_node_until_exit(|config| async move {
+				if cfg!(feature = "runtime-benchmarks") && config.role.is_authority() {
+					return Err("It is not allowed to run a collator node with the benchmarking runtime.".into());
+				};
+				
 				let para_id = chain_spec::Extensions::try_get(&config.chain_spec).map(|e| e.para_id);
 
 				let polkadot_cli = RelayChainCli::new(


### PR DESCRIPTION
Throws an error with a message when trying to start a collator node built with the `runtime-benchmarks` flag.
 Fixes: #208 
