### PR TITLE
chore: update registered currencies in dev chainspec

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -229,12 +229,10 @@ pub fn testnet_parachain_config(para_id: ParaId) -> Result<ChainSpec, String> {
 				hex!["30035c21ba9eda780130f2029a80c3e962f56588bc04c36be95a225cb536fb55"].into(), // SAME AS ROOT
 				vec![],
 				vec![
-					(b"hKSM".to_vec(), 1_000u128),
-					(b"hDOT".to_vec(), 1_000u128),
-					(b"hETH".to_vec(), 1_000u128),
-					(b"hUSDT".to_vec(), 1_000u128),
+					(b"KSM".to_vec(), 1_000u128),
+					(b"KUSD".to_vec(), 1_000u128),
 				],
-				vec![],
+				vec![(1, Price::from_float(0.0000212)), (2, Price::from_float(0.000806))],
 			)
 		},
 		// Bootnodes
@@ -318,12 +316,10 @@ pub fn parachain_development_config(para_id: ParaId) -> Result<ChainSpec, String
 				get_account_id_from_seed::<sr25519::Public>("Alice"), // SAME AS ROOT
 				get_vesting_config_for_test(),
 				vec![
-					(b"hKSM".to_vec(), 1_000u128),
-					(b"hDOT".to_vec(), 1_000u128),
-					(b"hETH".to_vec(), 1_000u128),
-					(b"hUSDT".to_vec(), 1_000u128),
+					(b"KSM".to_vec(), 1_000u128),
+					(b"KUSD".to_vec(), 1_000u128),
 				],
-				vec![(1, Price::from_float(0.5)), (2, Price::from(2))],
+				vec![(1, Price::from_float(0.0000212)), (2, Price::from_float(0.000806))],
 			)
 		},
 		// Bootnodes
@@ -469,12 +465,10 @@ pub fn local_parachain_config(para_id: ParaId) -> Result<ChainSpec, String> {
 				get_account_id_from_seed::<sr25519::Public>("Alice"), // SAME AS ROOT
 				get_vesting_config_for_test(),
 				vec![
-					(b"hKSM".to_vec(), 1_000u128),
-					(b"hDOT".to_vec(), 1_000u128),
-					(b"hETH".to_vec(), 1_000u128),
-					(b"hUSDT".to_vec(), 1_000u128),
+					(b"KSM".to_vec(), 1_000u128),
+					(b"KUSD".to_vec(), 1_000u128),
 				],
-				vec![],
+				vec![(1, Price::from_float(0.0000212)), (2, Price::from_float(0.000806))],
 			)
 		},
 		// Bootnodes

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -662,8 +662,6 @@ fn testnet_parachain_genesis(
 					vec![
 						(x.clone(), 1, 1_000_000_000u128 * UNITS),
 						(x.clone(), 2, 1_000_000_000u128 * UNITS),
-						(x.clone(), 3, 1_000_000_000u128 * UNITS),
-						(x.clone(), 4, 1_000_000_000u128 * UNITS),
 					]
 				})
 				.collect(),

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -21,12 +21,12 @@
 use basilisk_runtime::{
 	AccountId, AssetRegistryConfig, AuraId, Balance, BalancesConfig, CollatorSelectionConfig, CouncilConfig,
 	DusterConfig, ElectionsConfig, GenesisConfig, MultiTransactionPaymentConfig, OrmlNftConfig, ParachainInfoConfig,
-	SessionConfig, Signature, SudoConfig, SystemConfig, TechnicalCommitteeConfig, TokensConfig, VestingConfig, UNITS,
-	NATIVE_EXISTENTIAL_DEPOSIT, WASM_BINARY,
+	SessionConfig, Signature, SudoConfig, SystemConfig, TechnicalCommitteeConfig, TokensConfig, VestingConfig,
+	NATIVE_EXISTENTIAL_DEPOSIT, UNITS, WASM_BINARY,
 };
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
-use primitives::BlockNumber;
+use primitives::{AssetId, BlockNumber, Price};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use sc_telemetry::TelemetryEndpoints;
@@ -234,6 +234,7 @@ pub fn testnet_parachain_config(para_id: ParaId) -> Result<ChainSpec, String> {
 					(b"hETH".to_vec(), 1_000u128),
 					(b"hUSDT".to_vec(), 1_000u128),
 				],
+				vec![],
 			)
 		},
 		// Bootnodes
@@ -322,6 +323,7 @@ pub fn parachain_development_config(para_id: ParaId) -> Result<ChainSpec, String
 					(b"hETH".to_vec(), 1_000u128),
 					(b"hUSDT".to_vec(), 1_000u128),
 				],
+				vec![(1, Price::from_float(0.5)), (2, Price::from(2))],
 			)
 		},
 		// Bootnodes
@@ -390,6 +392,7 @@ pub fn benchmarks_development_config(para_id: ParaId) -> Result<ChainSpec, Strin
 				],
 				get_account_id_from_seed::<sr25519::Public>("Alice"), // SAME AS ROOT
 				get_vesting_config_for_test(),
+				vec![],
 				vec![],
 			)
 		},
@@ -471,6 +474,7 @@ pub fn local_parachain_config(para_id: ParaId) -> Result<ChainSpec, String> {
 					(b"hETH".to_vec(), 1_000u128),
 					(b"hUSDT".to_vec(), 1_000u128),
 				],
+				vec![],
 			)
 		},
 		// Bootnodes
@@ -606,6 +610,7 @@ fn testnet_parachain_genesis(
 	tx_fee_payment_account: AccountId,
 	vesting_list: Vec<(AccountId, BlockNumber, BlockNumber, u32, Balance)>,
 	registered_assets: Vec<(Vec<u8>, Balance)>, // (Asset name, Existential deposit)
+	accepted_assets: Vec<(AssetId, Price)>,     // (Asset id, Fallback price) - asset which fee can be paid with
 ) -> GenesisConfig {
 	GenesisConfig {
 		system: SystemConfig {
@@ -653,7 +658,7 @@ fn testnet_parachain_genesis(
 			native_existential_deposit: NATIVE_EXISTENTIAL_DEPOSIT,
 		},
 		multi_transaction_payment: MultiTransactionPaymentConfig {
-			currencies: vec![],
+			currencies: accepted_assets,
 			fallback_account: tx_fee_payment_account,
 		},
 		tokens: TokensConfig {


### PR DESCRIPTION
Updated registered assets in dev chainspec. 

KSM and KUSD are 2 registered assets. 

And both are enabled to be selected as currency to pay tx fee with with following prices:

1 BSX = 0.00806 KUSD
1 BSX = 0.0000212 KSM