### PR TITLE
ci: install toolchain according to file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,13 +77,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: git describe --tags --abbrev=0 --always
       - name: Install Rust
-        uses: actions-rs/toolchain@v1.0.7
+        uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
-          toolchain: nightly-2021-06-01
-          target: wasm32-unknown-unknown
-          override: true
-          default: true
       - name: Install clippy
         run: rustup component add clippy
       - name: Run clippy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: git describe --tags --abbrev=0 --always
       - name: Install Rust
-        uses: actions-rs/toolchain@v1.0.7
+        uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746
         with:
           profile: minimal
       - name: Install clippy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,10 +76,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
       - run: git describe --tags --abbrev=0 --always
-      - name: Install Rust
-        uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746
-        with:
-          profile: minimal
+      - name: Install rust
+        run: rustup show
       - name: Install clippy
         run: rustup component add clippy
       - name: Run clippy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: git describe --tags --abbrev=0 --always
       - name: Install Rust
-        uses: actions-rs/toolchain@v1.0.6
+        uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
       - name: Install clippy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,8 +76,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
       - run: git describe --tags --abbrev=0 --always
-      - name: Install rust
-        run: rustup show
+      - name: Install Rust
+        uses: codota/toolchain@00a8bf2bdcfe93aefd70422d3dec07337959d3a4
+        with:
+          profile: minimal
       - name: Install clippy
         run: rustup component add clippy
       - name: Run clippy


### PR DESCRIPTION
before there were actually 2 toolchains installed, but the only one specified in toolchain file was used. i have changed the action to the fixed one that is able to install just the toolchain that is actually used.

---
fixes #255 