### PR TITLE
chore: Refactor NFT Auctions tests

### DIFF
--- a/pallets/auctions/src/mock.rs
+++ b/pallets/auctions/src/mock.rs
@@ -178,3 +178,7 @@ fn last_event() -> Event {
 pub fn expect_event<E: Into<TestEvent>>(e: E) {
 	assert_eq!(last_event(), e.into());
 }
+
+pub fn run_to_block<T: frame_system::Config<BlockNumber = u64>>(n: u64) {
+	frame_system::Pallet::<T>::set_block_number(n);
+}

--- a/pallets/auctions/src/traits.rs
+++ b/pallets/auctions/src/traits.rs
@@ -17,13 +17,11 @@ pub enum Auction<T: Config> {
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
 pub struct EnglishAuction<T: Config> {
 	pub general_data: GeneralAuctionData<T>,
-	pub specific_data: EnglishAuctionData<T>,
+	pub specific_data: EnglishAuctionData,
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
-pub struct EnglishAuctionData<T: Config> {
-	pub reserve_price: BalanceOf<T>,
-}
+pub struct EnglishAuctionData {}
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
 pub struct GeneralAuctionData<T: Config> {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-10-22"
+channel = "nightly-2021-11-17"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
The PR refactors the tests for pallet_auctions:

* introduces a `predefined_test_ext()` for DRY code
* splits test cases into separate functions for better readibility and debug