### PR TITLE
feat: Add reserve_price to auctions and tests for Auction::TopUp

### DIFF
--- a/pallets/auctions/src/lib.rs
+++ b/pallets/auctions/src/lib.rs
@@ -25,7 +25,17 @@
 //! The Auctions pallet provides extendable auction functionality for NFTs.
 //!
 //! The pallet implements an NftAuction trait which allows users to extend the pallet by implementing other
-//! auction types. All auction types must implement bid() and close() functions at their interface.
+//! auction types. All auction types must implement the following instance functions at their interface:
+//! 
+//! - `create`
+//! 
+//! - `update`
+//! 
+//! - `bid`
+//! 
+//! - `close`
+//! 
+//! - `validate_general_data`
 //!
 //! The auction types share the same store called Auctions. Auction types are represented in a struct which holds
 //! two other structs with general_data (eg auction name, start, end) and specific_data for the given auction type.
@@ -49,10 +59,14 @@
 //! In an English auction, participants place bids in a running auction. Once the auction has reached its end time,
 //! the highest bid wins.
 //!
-//! The implementation of English auction allows sellers to set a starting price for the object, under which it will not
-//! be sold (auction.general_data.next_bid_min).
-//!
-//! It also extens the end time of the auction for any last-minute bids in order to prevent auction sniping.
+//! The implementation of English auction allows sellers to set a reserve price for the NFT
+//! (auction.general_data.reserve_price). The reserve_price acts as a minimum starting bid, preventing bidders 
+//! from placing bids below the reserve_price.
+//! When creating an English auction with a reserve_price, auction.general_data.reserve_price must be equal to
+//! auction.general_data.next_bid_min.
+//! 
+//! To avoid auction sniping, the pallet extends the end time of the auction for any late bids which are placed
+//! shortly before auction close.
 //!
 
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/pallets/auctions/src/lib.rs
+++ b/pallets/auctions/src/lib.rs
@@ -732,6 +732,8 @@ impl<T: Config> NftAuction<T::AccountId, T::AuctionId, BalanceOf<T>, Auction<T>>
 	/// First bidder does not pay anything
 	/// Everyone else has to pay the difference between his and next lowest bid
 	///
+	/// TODO: implement reserve_price after refactoring bid and close fns
+	/// 
 	fn close(&mut self) -> DispatchResult {
 		pallet_uniques::Pallet::<T>::thaw(
 			RawOrigin::Signed(self.general_data.owner.clone()).into(),

--- a/pallets/auctions/src/mock.rs
+++ b/pallets/auctions/src/mock.rs
@@ -61,6 +61,7 @@ parameter_types! {
 	pub const BidAddBlocks: u32 = 10;
 	pub const BidStepPerc: u32 = 10;
 	pub const MinAuctionDuration: u32 = 10;
+	pub const BidMinAmount: u32 = 1;
 }
 
 impl pallet_auctions::Config for Test {
@@ -74,6 +75,7 @@ impl pallet_auctions::Config for Test {
 	type BidAddBlocks = BidAddBlocks;
 	type BidStepPerc = BidStepPerc;
 	type MinAuctionDuration = MinAuctionDuration;
+	type BidMinAmount = BidMinAmount;
 }
 
 parameter_types! {

--- a/pallets/auctions/src/tests.rs
+++ b/pallets/auctions/src/tests.rs
@@ -47,6 +47,7 @@ pub fn predefined_test_ext() -> sp_io::TestExternalities {
 fn valid_general_auction_data() -> GeneralAuctionData<Test> {
 	GeneralAuctionData {
 		name: to_bounded_name(b"Auction 0".to_vec()).unwrap(),
+		reserve_price: 0,
 		last_bid: None,
 		start: 10u64,
 		end: 21u64,

--- a/pallets/auctions/src/traits.rs
+++ b/pallets/auctions/src/traits.rs
@@ -7,6 +7,8 @@ use sp_std::vec::Vec;
 pub trait NftAuction<AccountId, AuctionId, BalanceOf, NftAuction> {
 	fn create(&self, sender: AccountId, auction: &NftAuction) -> DispatchResult;
 
+	fn update(&self, sender: AccountId, auction_id: AuctionId, auction: NftAuction) -> DispatchResult;
+
 	fn bid(&mut self, bidder: AccountId, value: BalanceOf) -> DispatchResult;
 
 	fn close(&mut self) -> DispatchResult;
@@ -49,7 +51,7 @@ pub struct TopUpAuctionData<T: Config> {
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
 pub struct GeneralAuctionData<T: Config> {
 	pub name: BoundedVec<u8, <T as crate::Config>::AuctionsStringLimit>,
-	pub reserve_price: BalanceOf<T>,
+	pub reserve_price: Option<BalanceOf<T>>,
 	pub last_bid: Option<(<T as frame_system::Config>::AccountId, BalanceOf<T>)>,
 	pub next_bid_min: BalanceOf<T>,
 	pub start: <T as frame_system::Config>::BlockNumber,

--- a/pallets/auctions/src/traits.rs
+++ b/pallets/auctions/src/traits.rs
@@ -5,9 +5,13 @@ use scale_info::TypeInfo;
 use sp_std::vec::Vec;
 
 pub trait NftAuction<AccountId, AuctionId, BalanceOf, NftAuction> {
+	fn create(&self, sender: AccountId, auction: &NftAuction) -> DispatchResult;
+
 	fn bid(&mut self, bidder: AccountId, value: BalanceOf) -> DispatchResult;
 
 	fn close(&mut self) -> DispatchResult;
+
+	fn validate_general_data(&self) -> DispatchResult;
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
@@ -45,6 +49,7 @@ pub struct TopUpAuctionData<T: Config> {
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
 pub struct GeneralAuctionData<T: Config> {
 	pub name: BoundedVec<u8, <T as crate::Config>::AuctionsStringLimit>,
+	pub reserve_price: BalanceOf<T>,
 	pub last_bid: Option<(<T as frame_system::Config>::AccountId, BalanceOf<T>)>,
 	pub next_bid_min: BalanceOf<T>,
 	pub start: <T as frame_system::Config>::BlockNumber,

--- a/runtime/basilisk/src/lib.rs
+++ b/runtime/basilisk/src/lib.rs
@@ -751,6 +751,7 @@ parameter_types! {
 	pub const BidAddBlocks: u32 = 10; // Increase end time to avoid sniping
 	pub const BidStepPerc: u32 = 10; // Next bid step in percent
 	pub const MinAuctionDuration: u32 = 10; // Minimum auction duration
+	pub const BidMinAmount: u32 = 1; // Minimum bid amount
 }
 
 impl pallet_auctions::Config for Runtime {
@@ -764,6 +765,7 @@ impl pallet_auctions::Config for Runtime {
 	type BidAddBlocks = BidAddBlocks;
 	type BidStepPerc = BidStepPerc;
 	type MinAuctionDuration = MinAuctionDuration;
+	type BidMinAmount = BidMinAmount;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.


### PR DESCRIPTION
Resolves https://github.com/galacticcouncil/Basilisk-node/issues/309
Resolves https://github.com/galacticcouncil/Basilisk-node/issues/332

This PR:
* adds a reserve_price (RP) functionality to NFT auctions
* adds a validation for the starting bid (next_bid_min at create/update) which should always be greater than a predefined minimum to prevent attack vectors 
* extends tests for create / update / delete Auction::TopUp

How the RP is implemented:
* English: the RP serves as a starting bid - no bids under the RP are accepted
* TopUp: bids under the RP are accepted, however the auction is only won if the sum of bids has reached the reserve_price (to be implemented after TopUp refactor)