### PR TITLE
refactor: TopUp Auction

### DIFF
--- a/pallets/auctions/src/lib.rs
+++ b/pallets/auctions/src/lib.rs
@@ -406,8 +406,8 @@ pub mod pallet {
 			})
 		}
 
-		#[pallet::weight(<T as Config>::WeightInfo::auction_claim_locked_amounts())]
-		pub fn claim_locked_amount(_origin: OriginFor<T>, bidder: T::AccountId, auction_id: T::AuctionId) -> DispatchResult {
+		#[pallet::weight(<T as Config>::WeightInfo::claim_reserved_amounts())]
+		pub fn claim_reserved_amounts(_origin: OriginFor<T>, bidder: T::AccountId, auction_id: T::AuctionId) -> DispatchResult {
 			let claimable_amount = <ReservedAmounts<T>>::get(bidder.clone(), auction_id);
 			ensure!(claimable_amount > Zero::zero(), Error::<T>::NoReservedAmountAvailableToClaim);
 

--- a/pallets/auctions/src/lib.rs
+++ b/pallets/auctions/src/lib.rs
@@ -411,12 +411,12 @@ pub mod pallet {
 			let claimable_amount = <ReservedAmounts<T>>::get(bidder.clone(), auction_id);
 			ensure!(claimable_amount > Zero::zero(), Error::<T>::NoReservedAmountAvailableToClaim);
 
-			let maybe_auction = <Auctions<T>>::get(auction_id).ok_or(Error::<T>::AuctionNotExist)?;
-			match maybe_auction {
-				Auction::TopUp(auction) => {
-					ensure!(Pallet::<T>::is_auction_ended(&auction.general_data), Error::<T>::AuctionEndTimeNotReached);
-					ensure!(auction.general_data.closed, Error::<T>::CloseAuctionBeforeClaimingReservedAmounts);
-					ensure!(!Pallet::<T>::is_auction_won(&auction.general_data), Error::<T>::CannotClaimWonAuction);
+			let auction = <Auctions<T>>::get(auction_id).ok_or(Error::<T>::AuctionNotExist)?;
+			match auction {
+				Auction::TopUp(auction_object) => {
+					ensure!(Pallet::<T>::is_auction_ended(&auction_object.general_data), Error::<T>::AuctionEndTimeNotReached);
+					ensure!(auction_object.general_data.closed, Error::<T>::CloseAuctionBeforeClaimingReservedAmounts);
+					ensure!(!Pallet::<T>::is_auction_won(&auction_object.general_data), Error::<T>::CannotClaimWonAuction);
 
 					<<T as crate::Config>::Currency as Currency<T::AccountId>>::transfer(
 						&Pallet::<T>::get_auction_subaccount_id(&auction_id),
@@ -639,8 +639,7 @@ impl<T: Config> Pallet<T> {
 
 	/// A helper function which checks whether an auction ending block has been reached
 	fn is_auction_ended(general_auction_data: &GeneralAuctionData<T>) -> bool {
-		let block_number = <frame_system::Pallet<T>>::block_number();
-		block_number >= general_auction_data.end
+		<frame_system::Pallet<T>>::block_number() >= general_auction_data.end
 	}
 
 	/// A helper function which checks whether an auction is won

--- a/pallets/auctions/src/mock.rs
+++ b/pallets/auctions/src/mock.rs
@@ -1,5 +1,5 @@
 use crate as pallet_auctions;
-use frame_support::{parameter_types, traits::Everything};
+use frame_support::{parameter_types, traits::Everything, PalletId};
 use frame_system as system;
 use sp_core::{crypto::AccountId32, H256};
 use sp_runtime::{
@@ -62,6 +62,8 @@ parameter_types! {
 	pub const BidStepPerc: u32 = 10;
 	pub const MinAuctionDuration: u32 = 10;
 	pub const BidMinAmount: u32 = 1;
+	pub const AuctionsPalletId: PalletId = PalletId(*b"auctions");
+
 }
 
 impl pallet_auctions::Config for Test {
@@ -76,6 +78,7 @@ impl pallet_auctions::Config for Test {
 	type BidStepPerc = BidStepPerc;
 	type MinAuctionDuration = MinAuctionDuration;
 	type BidMinAmount = BidMinAmount;
+	type PalletId = AuctionsPalletId;
 }
 
 parameter_types! {

--- a/pallets/auctions/src/tests.rs
+++ b/pallets/auctions/src/tests.rs
@@ -1389,11 +1389,10 @@ fn claim_locked_amount_from_topup_auction_without_winner_should_work() {
 		let bob_balance_before = Balances::free_balance(&BOB);
 		let auction_subaccount_balance_before = Balances::free_balance(&get_auction_subaccount_id(0));
 
-		assert_ok!(AuctionsModule::claim_locked_amount(
-			Origin::signed(BOB),
-			BOB,
-			0
-		));
+		assert_noop!(
+			AuctionsModule::claim_locked_amount(Origin::signed(BOB), BOB, 0),
+			Error::<Test>::NoReservedAmountAvailableToClaim
+		);
 
 		let bob_balance_after = Balances::free_balance(&BOB);
 		let auction_subaccount_balance_after = Balances::free_balance(&get_auction_subaccount_id(0));

--- a/pallets/auctions/src/tests.rs
+++ b/pallets/auctions/src/tests.rs
@@ -1332,13 +1332,13 @@ fn close_topup_auction_which_is_already_closed_should_not_work() {
 }
 
 
-/// Claiming locked amount from a TopUp auction without winner
+/// Claiming reserved amounts from a TopUp auction
 ///
 /// Happy path
 /// 
 /// 
 #[test]
-fn claim_locked_amount_from_topup_auction_without_winner_should_work() {
+fn claim_reserved_amounts_from_topup_auction_without_winner_should_work() {
 	predefined_test_ext().execute_with(|| {
 		let mut general_auction_data = valid_general_auction_data();
 		general_auction_data.reserve_price = Some(1_500);
@@ -1371,7 +1371,7 @@ fn claim_locked_amount_from_topup_auction_without_winner_should_work() {
 		let bob_balance_before = Balances::free_balance(&BOB);
 		let auction_subaccount_balance_before = Balances::free_balance(&get_auction_subaccount_id(0));
 
-		assert_ok!(AuctionsModule::claim_locked_amount(
+		assert_ok!(AuctionsModule::claim_reserved_amounts(
 			Origin::signed(BOB),
 			BOB,
 			0
@@ -1388,7 +1388,7 @@ fn claim_locked_amount_from_topup_auction_without_winner_should_work() {
 		let auction_subaccount_balance_before = Balances::free_balance(&get_auction_subaccount_id(0));
 
 		assert_noop!(
-			AuctionsModule::claim_locked_amount(Origin::signed(BOB), BOB, 0),
+			AuctionsModule::claim_reserved_amounts(Origin::signed(BOB), BOB, 0),
 			Error::<Test>::NoReservedAmountAvailableToClaim
 		);
 
@@ -1401,7 +1401,7 @@ fn claim_locked_amount_from_topup_auction_without_winner_should_work() {
 		// Bob claims for Charlie
 		let charlie_balance_before = Balances::free_balance(&CHARLIE);
 
-		assert_ok!(AuctionsModule::claim_locked_amount(
+		assert_ok!(AuctionsModule::claim_reserved_amounts(
 			Origin::signed(BOB),
 			CHARLIE,
 			0
@@ -1416,7 +1416,7 @@ fn claim_locked_amount_from_topup_auction_without_winner_should_work() {
 }
 
 #[test]
-fn claim_locked_amount_from_topup_auction_with_winner_should_not_work() {
+fn claim_reserved_amounts_from_topup_auction_with_winner_should_not_work() {
 	predefined_test_ext().execute_with(|| {
 		let mut general_auction_data = valid_general_auction_data();
 		general_auction_data.reserve_price = Some(1_500);
@@ -1446,24 +1446,24 @@ fn claim_locked_amount_from_topup_auction_with_winner_should_not_work() {
 		assert_ok!(AuctionsModule::close(Origin::signed(ALICE), 0));
 
 		assert_noop!(
-			AuctionsModule::claim_locked_amount(Origin::signed(BOB), BOB, 0),
+			AuctionsModule::claim_reserved_amounts(Origin::signed(BOB), BOB, 0),
 			Error::<Test>::CannotClaimWonAuction
 		);
 	});
 }
 
 #[test]
-fn claim_locked_amount_from_nonexisting_auction_should_not_work() {
+fn claim_reserved_amounts_from_nonexisting_auction_should_not_work() {
 	predefined_test_ext().execute_with(|| {
 		assert_noop!(
-			AuctionsModule::claim_locked_amount(Origin::signed(BOB), BOB, 0),
+			AuctionsModule::claim_reserved_amounts(Origin::signed(BOB), BOB, 0),
 			Error::<Test>::NoReservedAmountAvailableToClaim
 		);
 	});
 }
 
 #[test]
-fn claim_locked_amount_from_running_topup_auction_should_not_work() {
+fn claim_reserved_amounts_from_running_topup_auction_should_not_work() {
 	predefined_test_ext().execute_with(|| {
 		let mut general_auction_data = valid_general_auction_data();
 		general_auction_data.reserve_price = Some(1_500);
@@ -1489,14 +1489,14 @@ fn claim_locked_amount_from_running_topup_auction_should_not_work() {
 		));
 
 		assert_noop!(
-			AuctionsModule::claim_locked_amount(Origin::signed(BOB), BOB, 0),
+			AuctionsModule::claim_reserved_amounts(Origin::signed(BOB), BOB, 0),
 			Error::<Test>::AuctionEndTimeNotReached
 		);
 	});
 }
 
 #[test]
-fn claim_locked_amount_from_not_closed_topup_auction_should_not_work() {
+fn claim_reserved_amounts_from_not_closed_topup_auction_should_not_work() {
 	predefined_test_ext().execute_with(|| {
 		let mut general_auction_data = valid_general_auction_data();
 		general_auction_data.reserve_price = Some(1_500);
@@ -1524,7 +1524,7 @@ fn claim_locked_amount_from_not_closed_topup_auction_should_not_work() {
 		run_to_block::<Test>(22);
 
 		assert_noop!(
-			AuctionsModule::claim_locked_amount(Origin::signed(BOB), BOB, 0),
+			AuctionsModule::claim_reserved_amounts(Origin::signed(BOB), BOB, 0),
 			Error::<Test>::CloseAuctionBeforeClaimingReservedAmounts
 		);
 	});

--- a/pallets/auctions/src/traits.rs
+++ b/pallets/auctions/src/traits.rs
@@ -4,12 +4,12 @@ use frame_support::{dispatch::DispatchResult, traits::Currency, BoundedVec};
 use scale_info::TypeInfo;
 use sp_std::vec::Vec;
 
-pub trait NftAuction<AccountId, AuctionId, BalanceOf, NftAuction> {
+pub trait NftAuction<AccountId, AuctionId, BalanceOf, NftAuction, Bid> {
 	fn create(&self, sender: AccountId, auction: &NftAuction) -> DispatchResult;
 
 	fn update(&self, sender: AccountId, auction_id: AuctionId, auction: NftAuction) -> DispatchResult;
 
-	fn bid(&mut self, auction_id: &AuctionId, bidder: AccountId, value: BalanceOf) -> DispatchResult;
+	fn bid(&mut self, auction_id: &AuctionId, bidder: AccountId, bid: &Bid) -> DispatchResult;
 
 	fn close(&mut self, auction_id: &AuctionId) -> DispatchResult;
 
@@ -31,22 +31,20 @@ pub struct EnglishAuction<T: Config> {
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
 pub struct TopUpAuction<T: Config> {
 	pub general_data: GeneralAuctionData<T>,
-	pub specific_data: TopUpAuctionData<T>,
+	pub specific_data: TopUpAuctionData,
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
-pub struct Bid<AccountId, Balance> {
-	pub bidder: AccountId,
-	pub amount: Balance,
+pub struct Bid<T: Config> {
+	pub amount: BalanceOf<T>,
+	pub block_number: T::BlockNumber,
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
 pub struct EnglishAuctionData {}
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
-pub struct TopUpAuctionData<T: Config> {
-	pub bids: Vec<Bid<T::AccountId, BalanceOf<T>>>,
-}
+pub struct TopUpAuctionData {}
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
 pub struct GeneralAuctionData<T: Config> {
@@ -66,6 +64,12 @@ pub struct GeneralAuctionData<T: Config> {
 
 /// Define type aliases for better readability
 pub type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+impl<T: Config> sp_std::fmt::Debug for Bid<T> {
+	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		write!(f, "Bid")
+	}
+}
 
 impl<T: Config> sp_std::fmt::Debug for Auction<T> {
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {

--- a/pallets/auctions/src/traits.rs
+++ b/pallets/auctions/src/traits.rs
@@ -9,9 +9,9 @@ pub trait NftAuction<AccountId, AuctionId, BalanceOf, NftAuction> {
 
 	fn update(&self, sender: AccountId, auction_id: AuctionId, auction: NftAuction) -> DispatchResult;
 
-	fn bid(&mut self, bidder: AccountId, value: BalanceOf) -> DispatchResult;
+	fn bid(&mut self, auction_id: &AuctionId, bidder: AccountId, value: BalanceOf) -> DispatchResult;
 
-	fn close(&mut self) -> DispatchResult;
+	fn close(&mut self, auction_id: &AuctionId) -> DispatchResult;
 
 	fn validate_general_data(&self) -> DispatchResult;
 }

--- a/pallets/auctions/src/traits.rs
+++ b/pallets/auctions/src/traits.rs
@@ -2,7 +2,6 @@ pub use crate::Config;
 use codec::{Decode, Encode};
 use frame_support::{dispatch::DispatchResult, traits::Currency, BoundedVec};
 use scale_info::TypeInfo;
-use sp_std::vec::Vec;
 
 pub trait NftAuction<AccountId, AuctionId, BalanceOf, NftAuction, Bid> {
 	fn create(&self, sender: AccountId, auction: &NftAuction) -> DispatchResult;

--- a/pallets/auctions/src/weights.rs
+++ b/pallets/auctions/src/weights.rs
@@ -47,7 +47,7 @@ pub trait WeightInfo {
 	fn bid() -> Weight;
 	fn destroy_auction() -> Weight;
 	fn close_auction() -> Weight;
-	fn claim_bids() -> Weight;
+	fn auction_claim_locked_amounts() -> Weight;
 }
 
 /// Weights for pallet_auction using the subauction node and recommended hardware.
@@ -79,7 +79,7 @@ impl<T: frame_system::Config> WeightInfo for BasiliskWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
-	fn claim_bids() -> Weight {
+	fn auction_claim_locked_amounts() -> Weight {
 		(74_809_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
@@ -113,7 +113,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
 	}
-	fn claim_bids() -> Weight {
+	fn auction_claim_locked_amounts() -> Weight {
 		(74_809_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(5 as Weight))

--- a/pallets/auctions/src/weights.rs
+++ b/pallets/auctions/src/weights.rs
@@ -47,6 +47,7 @@ pub trait WeightInfo {
 	fn bid() -> Weight;
 	fn destroy_auction() -> Weight;
 	fn close_auction() -> Weight;
+	fn claim_bids() -> Weight;
 }
 
 /// Weights for pallet_auction using the subauction node and recommended hardware.
@@ -78,6 +79,11 @@ impl<T: frame_system::Config> WeightInfo for BasiliskWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
+	fn claim_bids() -> Weight {
+		(74_809_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes(5 as Weight))
+	}
 }
 
 // For backwards compatibility and tests
@@ -103,6 +109,11 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
 	fn close_auction() -> Weight {
+		(74_809_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
+	}
+	fn claim_bids() -> Weight {
 		(74_809_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(5 as Weight))

--- a/pallets/auctions/src/weights.rs
+++ b/pallets/auctions/src/weights.rs
@@ -47,7 +47,7 @@ pub trait WeightInfo {
 	fn bid() -> Weight;
 	fn destroy_auction() -> Weight;
 	fn close_auction() -> Weight;
-	fn auction_claim_locked_amounts() -> Weight;
+	fn claim_reserved_amounts() -> Weight;
 }
 
 /// Weights for pallet_auction using the subauction node and recommended hardware.
@@ -79,7 +79,7 @@ impl<T: frame_system::Config> WeightInfo for BasiliskWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
-	fn auction_claim_locked_amounts() -> Weight {
+	fn claim_reserved_amounts() -> Weight {
 		(74_809_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
@@ -113,7 +113,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
 	}
-	fn auction_claim_locked_amounts() -> Weight {
+	fn claim_reserved_amounts() -> Weight {
 		(74_809_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(5 as Weight))

--- a/runtime/basilisk/src/lib.rs
+++ b/runtime/basilisk/src/lib.rs
@@ -766,6 +766,7 @@ impl pallet_auctions::Config for Runtime {
 	type BidStepPerc = BidStepPerc;
 	type MinAuctionDuration = MinAuctionDuration;
 	type BidMinAmount = BidMinAmount;
+	type PalletId = AuctionsPalletId;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -188,6 +188,11 @@ parameter_types! {
 	pub const MaxApprovals: u32 =  100;
 }
 
+// pallet-auctions
+parameter_types! {
+	pub const AuctionsPalletId: PalletId = PalletId(*b"auctions");
+}
+
 // pallet authorship
 parameter_types! {
 	pub const UncleGenerations: u32 = 0;

--- a/runtime/src/weights/auctions.rs
+++ b/runtime/src/weights/auctions.rs
@@ -75,7 +75,7 @@ impl<T: frame_system::Config> WeightInfo for BasiliskWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn claim_bids() -> Weight {
+	fn auction_claim_locked_amounts() -> Weight {
 		(32_486_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))

--- a/runtime/src/weights/auctions.rs
+++ b/runtime/src/weights/auctions.rs
@@ -75,4 +75,9 @@ impl<T: frame_system::Config> WeightInfo for BasiliskWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
+	fn claim_bids() -> Weight {
+		(32_486_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
 }

--- a/runtime/src/weights/auctions.rs
+++ b/runtime/src/weights/auctions.rs
@@ -75,7 +75,7 @@ impl<T: frame_system::Config> WeightInfo for BasiliskWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	fn auction_claim_locked_amounts() -> Weight {
+	fn claim_reserved_amounts() -> Weight {
 		(32_486_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))


### PR DESCRIPTION
This PR builds on https://github.com/galacticcouncil/Basilisk-node/pull/308
It delivers the missing pieces for finishing TopUp auctions

When a user bids on a topup auction, the amount which is bid is reserved (ie moved to a subaccount belonging to the auction). 

At auction close, the whole amount is transferred to the seller in case the lot is sold (ie reserve_price is met)

If there is no winner because the reserve price was not met, all bidders can claim back their (aggregated) reserved amounts

TODO: 
* Add documentation