### PR TITLE
ci: runtime version match check fixed

### DIFF
--- a/scripts/list_crate_updates.sh
+++ b/scripts/list_crate_updates.sh
@@ -180,7 +180,7 @@ if [ ${#RUNTIME_VERSION_DIFFS[@]} -ne 0 ]; then
 fi
 
 RUNTIME_CARGO_VERSIONS=( $(printf '%s\n' "${RUNTIME_CARGO_VERSIONS[@]}" | sort -u) )
-if [ ${#RUNTIME_CARGO_VERSIONS} -gt 1 ]; then
+if [ ${#RUNTIME_CARGO_VERSIONS[@]} -gt 1 ]; then
   echo "Runtime versions don't match."
   echo
 fi


### PR DESCRIPTION
Fix: version check always reports that runtime versions don't match.