### PR TITLE
fix: add missing pallet-proxy in std feature

### DIFF
--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -221,6 +221,7 @@ std = [
     "pallet-treasury/std",
     "pallet-collective/std",
     "pallet-democracy/std",
+    "pallet-proxy/std",
     "pallet-scheduler/std",
     "pallet-tips/std",
     "pallet-collator-selection/std",

--- a/runtime/basilisk/src/lib.rs
+++ b/runtime/basilisk/src/lib.rs
@@ -105,7 +105,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("basilisk"),
 	impl_name: create_runtime_str!("basilisk"),
 	authoring_version: 1,
-	spec_version: 43,
+	spec_version: 44,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
`cargo check -p basilisk-runtime` was failing when trying to compile `pallet-proxy` and I noticed it was missing in the std feature list for the runtime.