### PR TITLE
chore: fix runtime builds - basilisk and testing-basilisk

### DIFF
--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -231,6 +231,7 @@ std = [
     "scale-info/std",
     "pallet-preimage/std",
     "pallet-liquidity-mining/std",
+    "pallet-identity/std",
 ]
 try-runtime= [
     "frame-try-runtime",

--- a/runtime/testing-basilisk/Cargo.toml
+++ b/runtime/testing-basilisk/Cargo.toml
@@ -186,6 +186,7 @@ std = [
     "pallet-xyk/std",
     "pallet-duster/std",
     "pallet-xyk-rpc-runtime-api/std",
+    "pallet-lbp-rpc-runtime-api/std",
     "pallet-asset-registry/std",
     "pallet-exchange/std",
     "pallet-aura/std",
@@ -227,6 +228,8 @@ std = [
     "scale-info/std",
     "pallet-preimage/std",
     "pallet-liquidity-mining/std",
+    "pallet-identity/std",
+    "pallet-proxy/std",
 ]
 try-runtime= [
     "frame-try-runtime",


### PR DESCRIPTION
with recent changes - it was not possible to build basilisk-runtime or testing-basilisk which result in CI build failing ( it attempts to build standalone runtime).