### PR TITLE
fix!: Patch XCM Executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -875,7 +875,7 @@ dependencies = [
 [[package]]
 name = "bp-message-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bp-runtime",
  "frame-support",
@@ -887,7 +887,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bitvec",
  "bp-runtime",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "bp-rococo"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "frame-support",
  "hash-db",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bp-header-chain",
  "ed25519-dalek",
@@ -971,7 +971,7 @@ dependencies = [
 [[package]]
 name = "bp-wococo"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bp-message-dispatch",
  "bp-messages",
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -3880,7 +3880,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime-constants"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -4754,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "metered-channel"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "derive_more",
  "futures 0.3.21",
@@ -5549,7 +5549,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bp-message-dispatch",
  "bp-runtime",
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -5588,7 +5588,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bitvec",
  "bp-message-dispatch",
@@ -6473,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6491,7 +6491,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6964,7 +6964,7 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "futures 0.3.21",
  "polkadot-node-network-protocol",
@@ -6978,7 +6978,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "futures 0.3.21",
  "polkadot-node-network-protocol",
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "derive_more",
  "futures 0.3.21",
@@ -7013,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "futures 0.3.21",
  "lru 0.7.6",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -7056,7 +7056,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "beefy-primitives",
  "frame-benchmarking",
@@ -7086,7 +7086,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "always-assert",
  "derive_more",
@@ -7107,7 +7107,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "derive_more",
  "futures 0.3.21",
@@ -7142,7 +7142,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -7156,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
@@ -7176,7 +7176,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -7195,7 +7195,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "futures 0.3.21",
  "parity-scale-codec",
@@ -7213,7 +7213,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7241,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bitvec",
  "futures 0.3.21",
@@ -7261,7 +7261,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bitvec",
  "futures 0.3.21",
@@ -7279,7 +7279,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "futures 0.3.21",
  "polkadot-node-subsystem",
@@ -7294,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -7312,7 +7312,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "futures 0.3.21",
  "polkadot-node-subsystem",
@@ -7327,7 +7327,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
@@ -7344,7 +7344,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "futures 0.3.21",
  "kvdb",
@@ -7362,7 +7362,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -7379,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bitvec",
  "futures 0.3.21",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -7426,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "futures 0.3.21",
  "polkadot-node-primitives",
@@ -7442,7 +7442,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "futures 0.3.21",
  "memory-lru",
@@ -7460,7 +7460,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -7478,7 +7478,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bs58",
  "futures 0.3.21",
@@ -7497,7 +7497,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7515,7 +7515,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bounded-vec",
  "futures 0.3.21",
@@ -7537,7 +7537,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -7547,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "derive_more",
  "futures 0.3.21",
@@ -7566,7 +7566,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7594,7 +7594,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
@@ -7615,7 +7615,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer-gen"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -7632,7 +7632,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer-gen-proc-macro"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -7643,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -7660,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "polkadot-performance-test"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "env_logger",
  "kusama-runtime",
@@ -7675,7 +7675,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bitvec",
  "frame-system",
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -7736,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -7820,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -7867,7 +7867,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-constants"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -7879,7 +7879,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -7891,7 +7891,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -7933,7 +7933,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -8033,7 +8033,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "arrayvec 0.5.2",
  "derive_more",
@@ -8054,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8650,7 +8650,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "beefy-primitives",
  "bp-messages",
@@ -8725,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8764,6 +8764,7 @@ dependencies = [
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
+ "hex-literal",
  "hydradx-traits",
  "kusama-runtime",
  "orml-currencies",
@@ -8788,6 +8789,7 @@ dependencies = [
  "pallet-marketplace",
  "pallet-nft",
  "pallet-price-oracle",
+ "pallet-relaychain-info",
  "pallet-scheduler",
  "pallet-session",
  "pallet-sudo",
@@ -8805,6 +8807,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-runtime-parachains",
+ "pretty_assertions",
  "primitives",
  "sp-api",
  "sp-block-builder",
@@ -10262,7 +10265,7 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -12359,7 +12362,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -12445,7 +12448,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12596,7 +12599,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
@@ -12609,7 +12612,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12653,7 +12656,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.17"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12671,7 +12674,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.1.0"
-source = "git+https://github.com/paritytech//polkadot?rev=de0ecd4760b146ecf33f5e867d707d789e21e060#de0ecd4760b146ecf33f5e867d707d789e21e060"
+source = "git+https://github.com/apopiak/polkadot?rev=5987afea534400f38cd14f699433b9443cf08e42#5987afea534400f38cd14f699433b9443cf08e42"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,28 +150,28 @@ substrate-wasm-builder = { git = "https://github.com/paritytech//substrate", rev
 try-runtime-cli = { git = "https://github.com/paritytech//substrate", rev = "22d40c761a985482f93bbbea5ba4199bdba74f8e" }
 
 [patch."https://github.com/paritytech/polkadot"]
-kusama-runtime = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-pallet-xcm = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-cli = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-client = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-core-primitives = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-node-core-pvf = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-node-network-protocol = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-node-primitives = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-node-subsystem = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-overseer = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-parachain = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-primitives = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-runtime = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-runtime-common = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-runtime-parachains = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-service = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-polkadot-statement-table = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-rococo-runtime = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-westend-runtime = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-xcm = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-xcm-builder = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
-xcm-executor = { git = "https://github.com/paritytech//polkadot", rev = "de0ecd4760b146ecf33f5e867d707d789e21e060" }
+kusama-runtime = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+pallet-xcm = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-cli = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-client = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-core-primitives = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-node-core-pvf = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-node-network-protocol = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-node-primitives = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-node-subsystem = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-overseer = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-parachain = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-primitives = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-runtime = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-runtime-common = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-runtime-parachains = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-service = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+polkadot-statement-table = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+rococo-runtime = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+westend-runtime = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+xcm = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+xcm-builder = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
+xcm-executor = { git = "https://github.com/apopiak/polkadot", rev = "5987afea534400f38cd14f699433b9443cf08e42" }
 
 [patch."https://github.com/paritytech/cumulus"]
 pallet-collator-selection = { git = "https://github.com/paritytech//cumulus", rev = "76479e7fef3af7c8828a44647847b01afd5fefe5" }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -106,7 +106,11 @@ polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", 
 basilisk-runtime = { path = "../runtime/basilisk", default-features = false}
 kusama-runtime = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.17" }
 
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "0183def18220b7cb818184534f490d3453899b5d", default-features = false }
+
 [dev-dependencies]
+pretty_assertions = "1.2.1"
+hex-literal = "0.3.1"
 xcm-emulator = { git = "https://github.com/zqhxuyuan/xcm-simulator", branch = "v0.9.16" }
 
 [features]
@@ -176,4 +180,6 @@ std = [
     "basilisk-runtime/std",
     "hydradx-traits/std",
     "pallet-price-oracle/std",
+
+    "pallet-relaychain-info/std",
 ]

--- a/integration-tests/src/cross_chain_transfer.rs
+++ b/integration-tests/src/cross_chain_transfer.rs
@@ -1,4 +1,5 @@
 #![cfg(test)]
+use crate::determine_hash;
 use crate::kusama_test_net::*;
 
 use frame_support::{assert_noop, assert_ok};
@@ -6,6 +7,7 @@ use frame_support::{assert_noop, assert_ok};
 use polkadot_xcm::latest::prelude::*;
 
 use cumulus_primitives_core::ParaId;
+use hex_literal::hex;
 use orml_traits::currency::MultiCurrency;
 use sp_runtime::traits::AccountIdConversion;
 use xcm_emulator::TestExt;
@@ -255,5 +257,56 @@ fn fee_currency_set_on_xcm_transfer() {
 			basilisk_runtime::MultiTransactionPayment::get_currency(&AccountId::from(HITCHHIKER)),
 			Some(1)
 		);
+	});
+}
+
+#[test]
+fn unknown_assets_are_trapped() {
+	TestNet::reset();
+
+	Hydra::execute_with(|| {
+		assert_ok!(basilisk_runtime::XTokens::transfer(
+			basilisk_runtime::Origin::signed(ALICE.into()),
+			0,
+			30 * UNITS,
+			Box::new(
+				MultiLocation::new(
+					1,
+					X2(
+						Junction::Parachain(2000),
+						Junction::AccountId32 {
+							id: BOB,
+							network: NetworkId::Any,
+						}
+					)
+				)
+				.into()
+			),
+			399_600_000_000
+		));
+		assert_eq!(
+			basilisk_runtime::Balances::free_balance(&AccountId::from(ALICE)),
+			200 * UNITS - 30 * UNITS
+		);
+	});
+
+	Basilisk::execute_with(|| {
+		expect_basilisk_events(vec![
+			cumulus_pallet_xcmp_queue::Event::Fail(
+				Some(hex!["0315cdbe0f0e6bc2603b96470ab1f12e1f9e3d4a8e9db689f2e557b19e24f3d0"].into()),
+				XcmError::AssetNotFound,
+			)
+			.into(),
+			pallet_relaychain_info::Event::CurrentBlockNumbers {
+				parachain_block_number: 1,
+				relaychain_block_number: 1,
+			}
+			.into(),
+		]);
+		let origin = MultiLocation::new(1, X1(Parachain(3000)));
+		let loc = MultiLocation::new(1, X2(Parachain(3000), GeneralIndex(0)));
+		let asset: MultiAsset = (loc, 30 * UNITS).into();
+		let hash = determine_hash(&origin, vec![asset]);
+		assert_eq!(basilisk_runtime::PolkadotXcm::asset_trap(hash), 1);
 	});
 }

--- a/integration-tests/src/kusama_test_net.rs
+++ b/integration-tests/src/kusama_test_net.rs
@@ -14,6 +14,7 @@ use cumulus_primitives_core::ParaId;
 use frame_support::traits::GenesisBuild;
 use polkadot_primitives::v1::{BlockNumber, MAX_CODE_SIZE, MAX_POV_SIZE};
 use polkadot_runtime_parachains::configuration::HostConfiguration;
+use pretty_assertions::assert_eq;
 use sp_runtime::traits::AccountIdConversion;
 
 use xcm_emulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain};

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -3,3 +3,17 @@ mod fees;
 mod kusama_test_net;
 mod nft_marketplace;
 mod non_native_fee;
+
+use polkadot_xcm::{latest::prelude::*, VersionedMultiAssets};
+use sp_core::H256;
+use sp_runtime::traits::{BlakeTwo256, Hash};
+
+// Determine the hash for assets expected to be have been trapped.
+#[allow(unused)]
+pub(crate) fn determine_hash<M>(origin: &MultiLocation, assets: M) -> H256
+where
+	M: Into<MultiAssets>,
+{
+	let versioned = VersionedMultiAssets::from(assets.into());
+	BlakeTwo256::hash_of(&(origin, &versioned))
+}


### PR DESCRIPTION
Use a patched version of Polkadot that fixes the XCM executor to trap assets on failed instructions.

<!--- Provide a general summary of your changes in the Title above -->
<!--- We are using semantinc pull request to make our lives easier -->
<!--- Please use prefixes for the title and use ! before : if breaking like below -->
<!--- build: ci: docs: feat: perf: refactor: fix: style: test: refactor!: -->

## Description
<!--- Describe your changes in detail -->
This PR adds an integration test for asset trapping on receiving unknown assets and uses a patched Polkadot version that ensures the asset is trapped (and not burned).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue below using keyword like: Fixes: #0 -->
Based on https://github.com/paritytech/polkadot/compare/release-v0.9.17...apopiak:polkadot:apopiak/fix-xcm-executor-atomicity

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Assets that are not recognized on `BuyExecution` (and thus trigger an error) get burned in the XCMv2 executor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
+ runtime integration test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if necessary.
- [x] I have added tests to cover my changes, regression test if fixing an issue.
- [x] This is a breaking change.
