### PR TITLE
fix: ignore AMMHandler error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6507,7 +6507,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xyk"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-xyk'
-version = '5.0.1'
+version = '5.0.2'
 description = 'XYK automated market maker'
 authors = ['GalacticCouncil']
 edition = '2021'

--- a/pallets/xyk/src/lib.rs
+++ b/pallets/xyk/src/lib.rs
@@ -346,7 +346,7 @@ pub mod pallet {
 				T::MinPoolLiquidity::get(),
 			)?;
 
-			let _ = T::AMMHandler::on_create_pool(asset_pair.asset_in, asset_pair.asset_out)?;
+			let _ = T::AMMHandler::on_create_pool(asset_pair.asset_in, asset_pair.asset_out);
 
 			T::NonDustableWhitelistHandler::add_account(&pair_account)?;
 


### PR DESCRIPTION
Price oracle handler (AMMHandler) shouldn't throw an unhandled error in XYK pallet.