### PR TITLE
fix!: remove pallet deps from primitives crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "basilisk-runtime"
-version = "74.0.0"
+version = "75.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -11327,7 +11327,7 @@ dependencies = [
 
 [[package]]
 name = "testing-basilisk-runtime"
-version = "74.0.0"
+version = "75.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8161,11 +8161,9 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "6.3.1"
+version = "6.3.2"
 dependencies = [
  "frame-support",
- "frame-system",
- "pallet-nft",
  "parity-scale-codec",
  "primitive-types 0.10.1",
  "scale-info",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitives"
-version = "6.3.1"
+version = "6.3.2"
 authors = ["GalacticCouncil"]
 edition = "2021"
 repository = "https://github.com/galacticcouncil/Basilisk-node"
@@ -14,18 +14,14 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 primitive-types = { default-features = false, version = "0.10.1" }
 serde = { features = ["derive"], optional = true, version = "1.0.136" }
 
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "7156f1c15118b520860347fa9e07fb24a48187d2", default-features = false }
-
 # Substrate dependencies
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
 
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
-
 
 [features]
 default = ["std"]

--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilisk-runtime"
-version = "74.0.0"
+version = "75.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 homepage = "https://github.com/galacticcouncil/Basilisk-node"

--- a/runtime/basilisk/src/lib.rs
+++ b/runtime/basilisk/src/lib.rs
@@ -108,7 +108,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("basilisk"),
 	impl_name: create_runtime_str!("basilisk"),
 	authoring_version: 1,
-	spec_version: 74,
+	spec_version: 75,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/testing-basilisk/Cargo.toml
+++ b/runtime/testing-basilisk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing-basilisk-runtime"
-version = "74.0.0"
+version = "75.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 homepage = "https://github.com/galacticcouncil/Basilisk-node"

--- a/runtime/testing-basilisk/src/lib.rs
+++ b/runtime/testing-basilisk/src/lib.rs
@@ -132,7 +132,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("testing-basilisk"),
 	impl_name: create_runtime_str!("testing-basilisk"),
 	authoring_version: 1,
-	spec_version: 74,
+	spec_version: 75,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
primitives crates should avoid including complex dependencies where possible