### PR TITLE
fix: lm redeposit_lp_shares()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
  "pallet-nft",
  "pallet-preimage",
  "pallet-proxy",
- "pallet-relaychain-info 0.3.2 (git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495)",
+ "pallet-relaychain-info 0.3.2 (git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a)",
  "pallet-route-executor",
  "pallet-scheduler",
  "pallet-session",
@@ -3453,7 +3453,7 @@ dependencies = [
 [[package]]
 name = "hydradx-adapters"
 version = "0.2.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a#654b06312c800c4fbdd052e5b3a83ca15efed63a"
 dependencies = [
  "frame-support",
  "hydradx-traits 2.0.0",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "hydradx-traits"
 version = "2.0.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a#654b06312c800c4fbdd052e5b3a83ca15efed63a"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -5788,7 +5788,7 @@ dependencies = [
 [[package]]
 name = "pallet-currencies"
 version = "1.0.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a#654b06312c800c4fbdd052e5b3a83ca15efed63a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6016,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "pallet-liquidity-mining"
 version = "3.0.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a#654b06312c800c4fbdd052e5b3a83ca15efed63a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6122,7 +6122,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft"
 version = "7.1.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a#654b06312c800c4fbdd052e5b3a83ca15efed63a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6244,7 +6244,7 @@ dependencies = [
 [[package]]
 name = "pallet-price-oracle"
 version = "0.3.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a#654b06312c800c4fbdd052e5b3a83ca15efed63a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6305,7 +6305,7 @@ dependencies = [
 [[package]]
 name = "pallet-relaychain-info"
 version = "0.3.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a#654b06312c800c4fbdd052e5b3a83ca15efed63a"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -6320,7 +6320,7 @@ dependencies = [
 [[package]]
 name = "pallet-route-executor"
 version = "1.0.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a#654b06312c800c4fbdd052e5b3a83ca15efed63a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6497,7 +6497,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-multi-payment"
 version = "8.0.4"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a#654b06312c800c4fbdd052e5b3a83ca15efed63a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6515,7 +6515,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-pause"
 version = "0.1.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a#654b06312c800c4fbdd052e5b3a83ca15efed63a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9076,7 +9076,7 @@ dependencies = [
  "pallet-marketplace",
  "pallet-nft",
  "pallet-price-oracle",
- "pallet-relaychain-info 0.3.2 (git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495)",
+ "pallet-relaychain-info 0.3.2 (git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a)",
  "pallet-route-executor",
  "pallet-scheduler",
  "pallet-session",
@@ -11740,7 +11740,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "1.1.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a#654b06312c800c4fbdd052e5b3a83ca15efed63a"
 dependencies = [
  "frame-system",
  "pretty_assertions",
@@ -11795,7 +11795,7 @@ dependencies = [
  "pallet-nft",
  "pallet-preimage",
  "pallet-proxy",
- "pallet-relaychain-info 0.3.2 (git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495)",
+ "pallet-relaychain-info 0.3.2 (git+https://github.com/galacticcouncil/warehouse?rev=654b06312c800c4fbdd052e5b3a83ca15efed63a)",
  "pallet-route-executor",
  "pallet-scheduler",
  "pallet-session",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "basilisk-runtime"
-version = "89.0.0"
+version = "90.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -517,7 +517,7 @@ dependencies = [
  "hex-literal",
  "hydradx-adapters",
  "hydradx-traits 0.9.1",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-benchmarking",
  "orml-tokens",
  "orml-traits",
@@ -544,7 +544,7 @@ dependencies = [
  "pallet-nft",
  "pallet-preimage",
  "pallet-proxy",
- "pallet-relaychain-info 0.3.2 (git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10)",
+ "pallet-relaychain-info 0.3.2 (git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495)",
  "pallet-route-executor",
  "pallet-scheduler",
  "pallet-session",
@@ -1204,12 +1204,12 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "cumulus-pallet-xcmp-queue",
  "frame-support",
  "frame-system",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-tokens",
  "orml-traits",
  "orml-vesting",
@@ -3439,8 +3439,8 @@ dependencies = [
 
 [[package]]
 name = "hydra-dx-math"
-version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/HydraDX-math?rev=1b678b779fc9291aea4673b7865651ab091d44b3#1b678b779fc9291aea4673b7865651ab091d44b3"
+version = "5.1.4"
+source = "git+https://github.com/galacticcouncil/HydraDX-math?rev=fdf7d6cdfb6968b826e6035c20b261a78a733573#fdf7d6cdfb6968b826e6035c20b261a78a733573"
 dependencies = [
  "fixed",
  "num-traits",
@@ -3453,10 +3453,10 @@ dependencies = [
 [[package]]
 name = "hydradx-adapters"
 version = "0.2.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10#e85c3c68708c7d9789d18c0a230efd436fc5ea10"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
 dependencies = [
  "frame-support",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "log",
  "pallet-transaction-multi-payment",
  "parity-scale-codec",
@@ -3483,8 +3483,8 @@ dependencies = [
 
 [[package]]
 name = "hydradx-traits"
-version = "1.0.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10#e85c3c68708c7d9789d18c0a230efd436fc5ea10"
+version = "2.0.0"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -5788,7 +5788,7 @@ dependencies = [
 [[package]]
 name = "pallet-currencies"
 version = "1.0.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10#e85c3c68708c7d9789d18c0a230efd436fc5ea10"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5820,13 +5820,13 @@ dependencies = [
 
 [[package]]
 name = "pallet-duster"
-version = "3.1.10"
+version = "3.1.11"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "lazy_static",
  "orml-tokens",
  "orml-traits",
@@ -5990,14 +5990,14 @@ dependencies = [
 
 [[package]]
 name = "pallet-lbp"
-version = "4.6.5"
+version = "4.6.6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
  "hydra-dx-math 4.9.0",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-tokens",
  "orml-traits",
  "parity-scale-codec",
@@ -6015,14 +6015,14 @@ dependencies = [
 
 [[package]]
 name = "pallet-liquidity-mining"
-version = "2.0.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10#e85c3c68708c7d9789d18c0a230efd436fc5ea10"
+version = "3.0.0"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
 dependencies = [
  "frame-support",
  "frame-system",
- "hydra-dx-math 5.0.0",
+ "hydra-dx-math 5.1.4",
  "hydradx-traits 0.9.1",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-traits",
  "parity-scale-codec",
  "scale-info",
@@ -6033,7 +6033,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-marketplace"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6122,12 +6122,12 @@ dependencies = [
 [[package]]
 name = "pallet-nft"
 version = "7.1.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10#e85c3c68708c7d9789d18c0a230efd436fc5ea10"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-utilities",
  "pallet-uniques",
  "parity-scale-codec",
@@ -6244,12 +6244,12 @@ dependencies = [
 [[package]]
 name = "pallet-price-oracle"
 version = "0.3.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10#e85c3c68708c7d9789d18c0a230efd436fc5ea10"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -6305,7 +6305,7 @@ dependencies = [
 [[package]]
 name = "pallet-relaychain-info"
 version = "0.3.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10#e85c3c68708c7d9789d18c0a230efd436fc5ea10"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -6320,11 +6320,11 @@ dependencies = [
 [[package]]
 name = "pallet-route-executor"
 version = "1.0.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10#e85c3c68708c7d9789d18c0a230efd436fc5ea10"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
 dependencies = [
  "frame-support",
  "frame-system",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-traits",
  "parity-scale-codec",
  "scale-info",
@@ -6497,11 +6497,11 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-multi-payment"
 version = "8.0.4"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10#e85c3c68708c7d9789d18c0a230efd436fc5ea10"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
 dependencies = [
  "frame-support",
  "frame-system",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-traits",
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6515,7 +6515,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-pause"
 version = "0.1.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10#e85c3c68708c7d9789d18c0a230efd436fc5ea10"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xyk"
-version = "6.1.4"
+version = "6.1.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6676,7 +6676,7 @@ dependencies = [
  "frame-system-benchmarking",
  "hydra-dx-math 4.9.0",
  "hydradx-traits 0.9.1",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "log",
  "orml-tokens",
  "orml-traits",
@@ -6698,11 +6698,11 @@ dependencies = [
 
 [[package]]
 name = "pallet-xyk-liquidity-mining"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "frame-support",
  "frame-system",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "lazy_static",
  "log",
  "orml-currencies",
@@ -6724,13 +6724,13 @@ dependencies = [
 
 [[package]]
 name = "pallet-xyk-liquidity-mining-benchmarking"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-currencies",
  "orml-tokens",
  "orml-traits",
@@ -6767,7 +6767,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-runtime-mock"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "basilisk-runtime",
  "cumulus-pallet-aura-ext",
@@ -6787,7 +6787,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "hex-literal",
  "hydradx-adapters",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "kusama-runtime",
  "orml-tokens",
  "orml-traits",
@@ -8363,7 +8363,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "6.4.1"
+version = "6.4.2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9033,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "basilisk-runtime",
  "cumulus-pallet-aura-ext",
@@ -9053,7 +9053,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "hex-literal",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "kusama-runtime",
  "orml-tokens",
  "orml-traits",
@@ -9076,7 +9076,7 @@ dependencies = [
  "pallet-marketplace",
  "pallet-nft",
  "pallet-price-oracle",
- "pallet-relaychain-info 0.3.2 (git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10)",
+ "pallet-relaychain-info 0.3.2 (git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495)",
  "pallet-route-executor",
  "pallet-scheduler",
  "pallet-session",
@@ -11740,7 +11740,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "1.1.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10#e85c3c68708c7d9789d18c0a230efd436fc5ea10"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495#a7e28a3a7fba655d9d27668097a1666f4250a495"
 dependencies = [
  "frame-system",
  "pretty_assertions",
@@ -11748,7 +11748,7 @@ dependencies = [
 
 [[package]]
 name = "testing-basilisk-runtime"
-version = "89.0.0"
+version = "90.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -11769,7 +11769,7 @@ dependencies = [
  "frame-try-runtime",
  "hex-literal",
  "hydradx-adapters",
- "hydradx-traits 1.0.0",
+ "hydradx-traits 2.0.0",
  "orml-tokens",
  "orml-traits",
  "orml-unknown-tokens",
@@ -11795,7 +11795,7 @@ dependencies = [
  "pallet-nft",
  "pallet-preimage",
  "pallet-proxy",
- "pallet-relaychain-info 0.3.2 (git+https://github.com/galacticcouncil/warehouse?rev=e85c3c68708c7d9789d18c0a230efd436fc5ea10)",
+ "pallet-relaychain-info 0.3.2 (git+https://github.com/galacticcouncil/warehouse?rev=a7e28a3a7fba655d9d27668097a1666f4250a495)",
  "pallet-route-executor",
  "pallet-scheduler",
  "pallet-session",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -10,13 +10,13 @@ repository = "https://github.com/galacticcouncil/Basilisk-node"
 
 [dependencies]
 # Warehouse dependencies
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
-pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false}
+pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false}
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 
 pallet-xyk = { path = "../pallets/xyk",default-features = false}
 pallet-duster= { path = "../pallets/duster",default-features = false}
@@ -108,7 +108,7 @@ parachain-runtime-mock = { path = "parachain-runtime-mock", default-features = f
 [dev-dependencies]
 xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", rev = "0460d04c798028e7bef82c907082e11753ed173b" }
 hex-literal = "0.3.1"
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495" }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a" }
 pretty_assertions = "1.2.1"
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 test-case = "2.2.1"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "0.8.7"
+version = "0.8.8"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -10,13 +10,13 @@ repository = "https://github.com/galacticcouncil/Basilisk-node"
 
 [dependencies]
 # Warehouse dependencies
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false}
-pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false}
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
+pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 
 pallet-xyk = { path = "../pallets/xyk",default-features = false}
 pallet-duster= { path = "../pallets/duster",default-features = false}
@@ -108,7 +108,7 @@ parachain-runtime-mock = { path = "parachain-runtime-mock", default-features = f
 [dev-dependencies]
 xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", rev = "0460d04c798028e7bef82c907082e11753ed173b" }
 hex-literal = "0.3.1"
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10" }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495" }
 pretty_assertions = "1.2.1"
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 test-case = "2.2.1"

--- a/integration-tests/parachain-runtime-mock/Cargo.toml
+++ b/integration-tests/parachain-runtime-mock/Cargo.toml
@@ -14,14 +14,14 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 scale-info = { version = "2.1", default-features = false, features = ["derive"] }
 
 # Warehouse dependencies
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
-pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false}
+pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false}
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 
 pallet-xyk = { path = "../../pallets/xyk",default-features = false}
 pallet-duster= { path = "../../pallets/duster",default-features = false}

--- a/integration-tests/parachain-runtime-mock/Cargo.toml
+++ b/integration-tests/parachain-runtime-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parachain-runtime-mock"
-version = "0.1.6"
+version = "0.1.7"
 description = "A mock runtime for a parachain"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/parachain-runtime-mock/Cargo.toml
+++ b/integration-tests/parachain-runtime-mock/Cargo.toml
@@ -14,14 +14,14 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 scale-info = { version = "2.1", default-features = false, features = ["derive"] }
 
 # Warehouse dependencies
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false}
-pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false}
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
+pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 
 pallet-xyk = { path = "../../pallets/xyk",default-features = false}
 pallet-duster= { path = "../../pallets/duster",default-features = false}

--- a/pallets/duster/Cargo.toml
+++ b/pallets/duster/Cargo.toml
@@ -19,7 +19,7 @@ codec = { default-features = false, features = ["derive"], package = "parity-sca
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], optional = true, version = "1.0.136" }
 
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 
 # ORML dependencies
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
@@ -40,7 +40,7 @@ sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 
 [features]

--- a/pallets/duster/Cargo.toml
+++ b/pallets/duster/Cargo.toml
@@ -19,7 +19,7 @@ codec = { default-features = false, features = ["derive"], package = "parity-sca
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], optional = true, version = "1.0.136" }
 
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 
 # ORML dependencies
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
@@ -40,7 +40,7 @@ sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 
 [features]

--- a/pallets/duster/Cargo.toml
+++ b/pallets/duster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-duster"
-version = "3.1.10"
+version = "3.1.11"
 description = "Account duster"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/lbp/Cargo.toml
+++ b/pallets/lbp/Cargo.toml
@@ -22,7 +22,7 @@ serde = { features = ["derive"], optional = true, version = "1.0.136" }
 
 # Warehouse dependencies
 hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "7b95ae58e6a8a24c56da3511cef24d8c394801bf", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 
 ## Local dependencies
 primitives = { default-features = false, path = "../../primitives" }
@@ -44,7 +44,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
-test-utils = {git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
+test-utils = {git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false}
 
 [features]
 default = ["std"]

--- a/pallets/lbp/Cargo.toml
+++ b/pallets/lbp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-lbp"
-version = "4.6.5"
+version = "4.6.6"
 description = "HydraDX Liquidity Bootstrapping Pool Pallet"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/lbp/Cargo.toml
+++ b/pallets/lbp/Cargo.toml
@@ -22,7 +22,7 @@ serde = { features = ["derive"], optional = true, version = "1.0.136" }
 
 # Warehouse dependencies
 hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "7b95ae58e6a8a24c56da3511cef24d8c394801bf", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 
 ## Local dependencies
 primitives = { default-features = false, path = "../../primitives" }
@@ -44,7 +44,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
-test-utils = {git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false}
+test-utils = {git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
 
 [features]
 default = ["std"]

--- a/pallets/marketplace/Cargo.toml
+++ b/pallets/marketplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-marketplace"
-version = "5.0.7"
+version = "5.0.8"
 authors = ["GalacticCoucil"]
 description = "The marketplace for trading NFTs"
 edition = "2018"

--- a/pallets/marketplace/Cargo.toml
+++ b/pallets/marketplace/Cargo.toml
@@ -26,7 +26,7 @@ sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0
 pallet-uniques = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 
 # Warehouse dependency
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 
 # local dependency
 primitives = { default-features = false, path = "../../primitives" }

--- a/pallets/marketplace/Cargo.toml
+++ b/pallets/marketplace/Cargo.toml
@@ -26,7 +26,7 @@ sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0
 pallet-uniques = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 
 # Warehouse dependency
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 
 # local dependency
 primitives = { default-features = false, path = "../../primitives" }

--- a/pallets/xyk-liquidity-mining/Cargo.toml
+++ b/pallets/xyk-liquidity-mining/Cargo.toml
@@ -21,9 +21,9 @@ log = { version = "0.4.17", default-features = false }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 
 # HydraDX dependencies
-pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev="a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev="a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev="a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev="654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev="654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev="654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 
 primitives = { path = "../../primitives", default-features = false }
 

--- a/pallets/xyk-liquidity-mining/Cargo.toml
+++ b/pallets/xyk-liquidity-mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-xyk-liquidity-mining"
-version = "1.1.1"
+version = "1.1.2"
 description = "Liquidity mining"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/xyk-liquidity-mining/Cargo.toml
+++ b/pallets/xyk-liquidity-mining/Cargo.toml
@@ -21,9 +21,9 @@ log = { version = "0.4.17", default-features = false }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 
 # HydraDX dependencies
-pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev="e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev="e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev="e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev="a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev="a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev="a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 
 primitives = { path = "../../primitives", default-features = false }
 

--- a/pallets/xyk-liquidity-mining/benchmarking/Cargo.toml
+++ b/pallets/xyk-liquidity-mining/benchmarking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-xyk-liquidity-mining-benchmarking"
-version = "1.0.6"
+version = "1.0.7"
 description = "Liquidity Mining Benchmarking Module"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/xyk-liquidity-mining/benchmarking/Cargo.toml
+++ b/pallets/xyk-liquidity-mining/benchmarking/Cargo.toml
@@ -26,10 +26,10 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 
 # HydraDX dependencies
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev="a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev="654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false}
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev="fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
-pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev="a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev="a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev="654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev="654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 
 # Substrate dependencies
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }

--- a/pallets/xyk-liquidity-mining/benchmarking/Cargo.toml
+++ b/pallets/xyk-liquidity-mining/benchmarking/Cargo.toml
@@ -26,10 +26,10 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 
 # HydraDX dependencies
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev="e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false}
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev="a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev="fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
-pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev="e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev="e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev="a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev="a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 
 # Substrate dependencies
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }

--- a/pallets/xyk-liquidity-mining/src/tests/mock.rs
+++ b/pallets/xyk-liquidity-mining/src/tests/mock.rs
@@ -75,6 +75,11 @@ pub const BSX_KSM_ASSET_PAIR: AssetPair = AssetPair {
 	asset_out: KSM,
 };
 
+pub const BSX_ACA_ASSET_PAIR: AssetPair = AssetPair {
+	asset_in: BSX,
+	asset_out: ACA,
+};
+
 pub const BSX_DOT_ASSET_PAIR: AssetPair = AssetPair {
 	asset_in: BSX,
 	asset_out: DOT,
@@ -663,7 +668,7 @@ impl hydradx_traits::liquidity_mining::Mutate<AccountId, AssetId, BlockNumber> f
 		yield_farm_id: u32,
 		deposit_id: u128,
 		get_token_value_of_lp_shares: fn(AssetId, Self::AmmPoolId, Balance) -> Result<Self::Balance, Self::Error>,
-	) -> Result<Self::Balance, Self::Error> {
+	) -> Result<(Self::Balance, Self::AmmPoolId), Self::Error> {
 		let deposit = DEPOSITS.with(|v| {
 			let mut p = v.borrow_mut();
 			let mut deposit = p.get_mut(&deposit_id).unwrap();
@@ -691,7 +696,7 @@ impl hydradx_traits::liquidity_mining::Mutate<AccountId, AssetId, BlockNumber> f
 			)
 		});
 
-		Ok(deposit.shares_amount)
+		Ok((deposit.shares_amount, deposit.amm_pool_id))
 	}
 
 	fn claim_rewards(

--- a/pallets/xyk-liquidity-mining/src/tests/redeposit_shares.rs
+++ b/pallets/xyk-liquidity-mining/src/tests/redeposit_shares.rs
@@ -255,3 +255,50 @@ fn redeposit_shares_should_fail_when_nft_owner_is_not_found() {
 			);
 		})
 }
+
+#[test]
+fn redeposit_shares_should_fail_when_asset_pair_is_not_in_the_deposit() {
+	ExtBuilder::default()
+		.with_endowed_accounts(vec![
+			(BOB, BSX, 1_000_000 * ONE),
+			(BOB, ACA, 1_000_000 * ONE),
+			(CHARLIE, BSX_KSM_SHARE_ID, 200 * ONE),
+		])
+		.with_amm_pool(BSX_KSM_AMM, BSX_KSM_SHARE_ID, BSX_KSM_ASSET_PAIR)
+		.with_amm_pool(BSX_ACA_AMM, BSX_ACA_SHARE_ID, BSX_ACA_ASSET_PAIR)
+		.with_global_farm(
+			500_000 * ONE,
+			20_000,
+			10,
+			BSX,
+			BSX,
+			ALICE,
+			Perquintill::from_percent(1),
+			ONE,
+			One::one(),
+		)
+		.with_global_farm(
+			500_000 * ONE,
+			20_000,
+			10,
+			BSX,
+			BSX,
+			BOB,
+			Perquintill::from_percent(1),
+			ONE,
+			One::one(),
+		)
+		.with_yield_farm(ALICE, 1, One::one(), None, BSX_KSM_ASSET_PAIR)
+		.with_yield_farm(BOB, 2, One::one(), None, BSX_KSM_ASSET_PAIR)
+		.with_deposit(CHARLIE, 1, 3, BSX_KSM_ASSET_PAIR, 100 * ONE)
+		.build()
+		.execute_with(|| {
+			set_block_number(50_000);
+
+			//Act
+			assert_noop!(
+				LiquidityMining::redeposit_shares(Origin::signed(CHARLIE), 2, 4, BSX_ACA_ASSET_PAIR, 1),
+				Error::<Test>::InvalidAssetPair
+			);
+		})
+}

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-xyk'
-version = '6.1.4'
+version = '6.1.5'
 description = 'XYK automated market maker'
 authors = ['GalacticCouncil']
 edition = '2021'

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -32,7 +32,7 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-utilities = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 
 # HydraDX dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 registry-traits = { package="hydradx-traits", git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
 
 # Substrate dependencies

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -32,7 +32,7 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-utilities = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.29", default-features = false }
 
 # HydraDX dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 registry-traits = { package="hydradx-traits", git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
 
 # Substrate dependencies

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitives"
-version = "6.4.1"
+version = "6.4.2"
 authors = ["GalacticCouncil"]
 edition = "2021"
 repository = "https://github.com/galacticcouncil/Basilisk-node"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -16,7 +16,7 @@ serde = { features = ["derive"], optional = true, version = "1.0.136" }
 static_assertions = "1.1.0"
 
 # Warehouse dependencies
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 
 # Substrate dependencies
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -16,7 +16,7 @@ serde = { features = ["derive"], optional = true, version = "1.0.136" }
 static_assertions = "1.1.0"
 
 # Warehouse dependencies
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 
 # Substrate dependencies
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }

--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -39,18 +39,18 @@ pallet-tips = { git = "https://github.com/paritytech/substrate", branch = "polka
 pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 
 # Warehouse dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false}
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 #NOTE: we are not using latest asset registry for now.
 registry-traits = { package="hydradx-traits", git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse",rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse",rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 
 # collator support
 pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29", default-features = false }

--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilisk-runtime"
-version = "89.0.0"
+version = "90.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 homepage = "https://github.com/galacticcouncil/Basilisk-node"

--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -39,18 +39,18 @@ pallet-tips = { git = "https://github.com/paritytech/substrate", branch = "polka
 pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 
 # Warehouse dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false}
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 #NOTE: we are not using latest asset registry for now.
 registry-traits = { package="hydradx-traits", git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse",rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse",rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 
 # collator support
 pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29", default-features = false }

--- a/runtime/basilisk/src/lib.rs
+++ b/runtime/basilisk/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("basilisk"),
 	impl_name: create_runtime_str!("basilisk"),
 	authoring_version: 1,
-	spec_version: 89,
+	spec_version: 90,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -26,13 +26,13 @@ pallet-marketplace = { path = '../../pallets/marketplace', default-features = fa
 pallet-xyk-liquidity-mining = { path = "../../pallets/xyk-liquidity-mining", default-features=false}
 
 # Warehouse dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false}
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 
 # Substrate dependencies
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common-runtime"
-version = "2.3.4"
+version = "2.3.5"
 authors = ["GalacticCouncil"]
 edition = "2021"
 homepage = "https://github.com/galacticcouncil/Basilisk-node"

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -26,13 +26,13 @@ pallet-marketplace = { path = '../../pallets/marketplace', default-features = fa
 pallet-xyk-liquidity-mining = { path = "../../pallets/xyk-liquidity-mining", default-features=false}
 
 # Warehouse dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false}
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 
 # Substrate dependencies
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }

--- a/runtime/testing-basilisk/Cargo.toml
+++ b/runtime/testing-basilisk/Cargo.toml
@@ -39,16 +39,16 @@ pallet-tips = { git = "https://github.com/paritytech/substrate", branch = "polka
 pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 
 # Warehouse dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false}
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
-warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "e85c3c68708c7d9789d18c0a230efd436fc5ea10", default-features = false }
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
 
 # collator support
 pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29", default-features = false }

--- a/runtime/testing-basilisk/Cargo.toml
+++ b/runtime/testing-basilisk/Cargo.toml
@@ -39,16 +39,16 @@ pallet-tips = { git = "https://github.com/paritytech/substrate", branch = "polka
 pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 
 # Warehouse dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false}
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false}
 pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "fcebd285141ce9ed15136f6102fa6396605d96af", default-features = false }
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
-warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "a7e28a3a7fba655d9d27668097a1666f4250a495", default-features = false }
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
+warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "654b06312c800c4fbdd052e5b3a83ca15efed63a", default-features = false }
 
 # collator support
 pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29", default-features = false }

--- a/runtime/testing-basilisk/Cargo.toml
+++ b/runtime/testing-basilisk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing-basilisk-runtime"
-version = "89.0.0"
+version = "90.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 homepage = "https://github.com/galacticcouncil/Basilisk-node"

--- a/runtime/testing-basilisk/src/lib.rs
+++ b/runtime/testing-basilisk/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("testing-basilisk"),
 	impl_name: create_runtime_str!("testing-basilisk"),
 	authoring_version: 1,
-	spec_version: 89,
+	spec_version: 90,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR updates repo to latest warehouse and fixes bug in liquidity-mining's `redeposit_lp_shares()` function.

# Bug:
`AssetPair` provided to `redeposit_lp_shares()` by users  is not checked with `Deposit` so users can provide different `AssetPair` than is `Deposit` for. 
This can result in wrong information in the event or/and bypassing xyk pool existence check.

# Solution:
Check `amm_pool_id` from the deposit with `amm_pool_id` generated from `AssetPair`.