### PR TITLE
feat: asset registry xcm rate limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,8 +3778,8 @@ dependencies = [
 
 [[package]]
 name = "hydra-dx-math"
-version = "7.0.1"
-source = "git+https://github.com/galacticcouncil/HydraDX-math?rev=35e5c0775a07e057ed5247ba96dfa254d691f034#35e5c0775a07e057ed5247ba96dfa254d691f034"
+version = "7.1.0"
+source = "git+https://github.com/galacticcouncil/HydraDX-math?rev=380b80b59bbf62abb8848fb8a10bb206861eab41#380b80b59bbf62abb8848fb8a10bb206861eab41"
 dependencies = [
  "fixed",
  "num-traits",
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "hydradx-adapters"
 version = "0.3.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-support",
  "hydradx-traits",
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "hydradx-traits"
 version = "2.3.0"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -5988,8 +5988,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-registry"
-version = "2.1.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+version = "2.2.0"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6245,7 +6245,7 @@ dependencies = [
 [[package]]
 name = "pallet-currencies"
 version = "1.2.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6280,7 +6280,7 @@ dependencies = [
 [[package]]
 name = "pallet-duster"
 version = "3.2.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6364,7 +6364,7 @@ dependencies = [
 [[package]]
 name = "pallet-ema-oracle"
 version = "1.0.3"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6501,8 +6501,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-liquidity-mining"
-version = "4.2.2"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+version = "4.2.3"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6592,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft"
 version = "7.1.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "pallet-price-oracle"
 version = "0.3.3"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6815,7 +6815,7 @@ dependencies = [
 [[package]]
 name = "pallet-relaychain-info"
 version = "0.3.3"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -6830,7 +6830,7 @@ dependencies = [
 [[package]]
 name = "pallet-route-executor"
 version = "1.0.3"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7025,7 +7025,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-multi-payment"
 version = "9.0.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7043,7 +7043,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-pause"
 version = "0.1.3"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12662,7 +12662,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "1.1.1"
-source = "git+https://github.com/galacticcouncil/warehouse?rev=f64f50255965a1177d28bbc969a371013584bbdd#f64f50255965a1177d28bbc969a371013584bbdd"
+source = "git+https://github.com/galacticcouncil/warehouse?rev=d6a78b5d51bc8af525d2b8f856efcfce2159e334#d6a78b5d51bc8af525d2b8f856efcfce2159e334"
 dependencies = [
  "frame-system",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "basilisk-runtime"
-version = "95.0.0"
+version = "96.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "2.3.9"
+version = "2.3.10"
 dependencies = [
  "cumulus-pallet-xcmp-queue",
  "frame-support",
@@ -6476,7 +6476,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-lbp"
-version = "4.6.10"
+version = "4.6.11"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6518,7 +6518,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-marketplace"
-version = "5.0.12"
+version = "5.0.13"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7217,7 +7217,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xyk"
-version = "6.2.4"
+version = "6.2.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7246,7 +7246,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xyk-liquidity-mining"
-version = "1.1.6"
+version = "1.1.7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7272,7 +7272,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xyk-liquidity-mining-benchmarking"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7314,7 +7314,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-runtime-mock"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "basilisk-runtime",
  "common-runtime",
@@ -9779,7 +9779,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-integration-tests"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "basilisk-runtime",
  "cumulus-pallet-aura-ext",
@@ -12670,7 +12670,7 @@ dependencies = [
 
 [[package]]
 name = "testing-basilisk-runtime"
-version = "95.0.0"
+version = "96.0.0"
 dependencies = [
  "common-runtime",
  "cumulus-pallet-aura-ext",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -10,15 +10,15 @@ repository = "https://github.com/galacticcouncil/Basilisk-node"
 
 [dependencies]
 # Warehouse dependencies
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 pallet-xyk = { path = "../pallets/xyk",default-features = false}
 pallet-lbp = { path = "../pallets/lbp", default-features = false }
@@ -109,7 +109,7 @@ parachain-runtime-mock = { path = "parachain-runtime-mock", default-features = f
 [dev-dependencies]
 xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", rev = "754f3b90ecc65af735a6c9a2e1792c5253926ff6" }
 hex-literal = "0.4.1"
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd" }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334" }
 pretty_assertions = "1.2.1"
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 test-case = "3.1.0"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "0.9.3"
+version = "0.9.4"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/parachain-runtime-mock/Cargo.toml
+++ b/integration-tests/parachain-runtime-mock/Cargo.toml
@@ -14,15 +14,15 @@ codec = { package = "parity-scale-codec", version = "3.4.0", default-features = 
 scale-info = { version = "2.3.1", default-features = false, features = ["derive"] }
 
 # Warehouse dependencies
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-price-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 pallet-xyk = { path = "../../pallets/xyk",default-features = false}
 pallet-lbp = { path = "../../pallets/lbp", default-features = false }
@@ -111,7 +111,7 @@ kusama-runtime = { git = "https://github.com/paritytech/polkadot", branch = "rel
 [dev-dependencies]
 xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", rev = "6847a58888e483f0ed2e0b72f90e00767ea0ecac" }
 hex-literal = "0.4.1"
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd" }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334" }
 pretty_assertions = "1.2.1"
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 test-case = "3.1.0"

--- a/integration-tests/parachain-runtime-mock/Cargo.toml
+++ b/integration-tests/parachain-runtime-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parachain-runtime-mock"
-version = "0.2.3"
+version = "0.2.4"
 description = "A mock runtime for a parachain"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/lbp/Cargo.toml
+++ b/pallets/lbp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-lbp"
-version = "4.6.10"
+version = "4.6.11"
 description = "HydraDX Liquidity Bootstrapping Pool Pallet"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/lbp/Cargo.toml
+++ b/pallets/lbp/Cargo.toml
@@ -21,9 +21,9 @@ primitive-types = { default-features = false, version = "0.12.0" }
 serde = { features = ["derive"], optional = true, version = "1.0.136" }
 
 # Warehouse dependencies
-hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "35e5c0775a07e057ed5247ba96dfa254d691f034", default-features = false }
+hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "380b80b59bbf62abb8848fb8a10bb206861eab41", default-features = false }
 
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 ## Local dependencies
 primitives = { default-features = false, path = "../../primitives" }
@@ -45,7 +45,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
-test-utils = {git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
+test-utils = {git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
 
 [features]
 default = ["std"]

--- a/pallets/marketplace/Cargo.toml
+++ b/pallets/marketplace/Cargo.toml
@@ -26,7 +26,7 @@ sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0
 pallet-uniques = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 
 # Warehouse dependency
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 # local dependency
 primitives = { default-features = false, path = "../../primitives" }

--- a/pallets/marketplace/Cargo.toml
+++ b/pallets/marketplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-marketplace"
-version = "5.0.12"
+version = "5.0.13"
 authors = ["GalacticCoucil"]
 description = "The marketplace for trading NFTs"
 edition = "2018"

--- a/pallets/xyk-liquidity-mining/Cargo.toml
+++ b/pallets/xyk-liquidity-mining/Cargo.toml
@@ -24,9 +24,9 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 primitives = { path = "../../primitives", default-features = false }
 
 # Warehouse dependencies
-pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev="f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev="f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev="f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev="d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev="d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev="d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 # Substrate dependencies
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }

--- a/pallets/xyk-liquidity-mining/Cargo.toml
+++ b/pallets/xyk-liquidity-mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-xyk-liquidity-mining"
-version = "1.1.6"
+version = "1.1.7"
 description = "Liquidity mining"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/xyk-liquidity-mining/benchmarking/Cargo.toml
+++ b/pallets/xyk-liquidity-mining/benchmarking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-xyk-liquidity-mining-benchmarking"
-version = "1.0.11"
+version = "1.0.12"
 description = "Liquidity Mining Benchmarking Module"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/pallets/xyk-liquidity-mining/benchmarking/Cargo.toml
+++ b/pallets/xyk-liquidity-mining/benchmarking/Cargo.toml
@@ -25,11 +25,11 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.38", default-features = false }
 
 # HydraDX dependencies
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev="f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev="f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev="f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev="f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev="f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev="d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev="d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-liquidity-mining = { git = "https://github.com/galacticcouncil/warehouse", rev="d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev="d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev="d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 # Substrate dependencies
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-xyk'
-version = "6.2.4"
+version = "6.2.5"
 description = 'XYK automated market maker'
 authors = ['GalacticCouncil']
 edition = '2021'

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -21,7 +21,7 @@ primitive-types = { default-features = false, version = "0.12.0" }
 serde = { features = ['derive'], optional = true, version = '1.0.136' }
 log = { version = "0.4.17", default-features = false }
 
-hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "35e5c0775a07e057ed5247ba96dfa254d691f034", default-features = false }
+hydra-dx-math = { git = "https://github.com/galacticcouncil/HydraDX-math", rev = "380b80b59bbf62abb8848fb8a10bb206861eab41", default-features = false }
 
 # Local dependencies
 primitives = {path = '../../primitives', default-features = false}
@@ -32,7 +32,7 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-utilities = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.38", default-features = false }
 
 # HydraDX dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 # Substrate dependencies
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false, optional = true }
@@ -44,7 +44,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 
 [dev-dependencies]
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38" }
 proptest = "1.0.0"

--- a/pallets/xyk/src/tests/creation.rs
+++ b/pallets/xyk/src/tests/creation.rs
@@ -380,6 +380,7 @@ fn share_asset_id_should_be_offset() {
 			Some(next_asset_id),
 			None,
 			None,
+			None,
 		));
 
 		// Create_pool doesn't register new share token if it already exists

--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilisk-runtime"
-version = "95.0.0"
+version = "96.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 homepage = "https://github.com/galacticcouncil/Basilisk-node"

--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -38,18 +38,18 @@ pallet-tips = { git = "https://github.com/paritytech/substrate", branch = "polka
 pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 
 # Warehouse dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse",rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse",rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 # collator support
 pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.38", default-features = false }

--- a/runtime/basilisk/src/benchmarking/marketplace.rs
+++ b/runtime/basilisk/src/benchmarking/marketplace.rs
@@ -43,6 +43,7 @@ fn create_collection_and_mint(
 		None,
 		None,
 		None,
+		None,
 	));
 	let asset_id = AssetRegistry::retrieve_asset(&name).unwrap();
 	assert_ok!(AssetRegistry::set_location(

--- a/runtime/basilisk/src/benchmarking/mod.rs
+++ b/runtime/basilisk/src/benchmarking/mod.rs
@@ -32,6 +32,7 @@ pub fn register_asset(name: Vec<u8>, deposit: Balance) -> Result<AssetId, ()> {
 		pallet_asset_registry::AssetType::<AssetId>::Token,
 		deposit,
 		None,
+		None,
 	)
 	.map_err(|_| ())
 }
@@ -51,6 +52,7 @@ pub fn update_asset(asset_id: AssetId, name: Vec<u8>, deposit: Balance) -> Resul
 		name,
 		pallet_asset_registry::AssetType::<AssetId>::Token,
 		Some(deposit),
+		None,
 	)
 	.map_err(|_| ())
 }

--- a/runtime/basilisk/src/lib.rs
+++ b/runtime/basilisk/src/lib.rs
@@ -1055,6 +1055,7 @@ pub type Executive = frame_executive::Executive<
 		ParachainSystem,
 		migrations::OnRuntimeUpgradeMigration,
 		migrations::MigrateRegistryLocationToV3<Runtime>,
+		migrations::XcmRateLimitMigration,
 	),
 >;
 

--- a/runtime/basilisk/src/lib.rs
+++ b/runtime/basilisk/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("basilisk"),
 	impl_name: create_runtime_str!("basilisk"),
 	authoring_version: 1,
-	spec_version: 95,
+	spec_version: 96,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/basilisk/src/migrations.rs
+++ b/runtime/basilisk/src/migrations.rs
@@ -82,7 +82,6 @@ where
 	}
 }
 
-
 pub struct XcmRateLimitMigration;
 impl OnRuntimeUpgrade for XcmRateLimitMigration {
 	#[cfg(feature = "try-runtime")]

--- a/runtime/basilisk/src/migrations.rs
+++ b/runtime/basilisk/src/migrations.rs
@@ -54,7 +54,7 @@ where
 {
 	fn on_runtime_upgrade() -> Weight {
 		log::info!(
-			target: "asset-registry",
+			target: "runtime::asset-registry",
 			"MigrateRegistryLocationToV3::on_runtime_upgrade: migrating asset locations to v3"
 		);
 
@@ -79,5 +79,35 @@ where
 			LocationAssets::<T>::insert(new_location, asset_id);
 		}
 		weight
+	}
+}
+
+
+pub struct XcmRateLimitMigration;
+impl OnRuntimeUpgrade for XcmRateLimitMigration {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+		frame_support::log::info!("PreMigrate Asset Registry Pallet start");
+		pallet_asset_registry::migration::v1::pre_migrate::<Runtime>();
+		frame_support::log::info!("PreMigrate Asset Registry Pallet end");
+
+		Ok(vec![])
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		log::info!(
+			target: "runtime::asset-registry",
+			"XcmRateLimitMigration::on_runtime_upgrade: migrating asset details to include xcm rate limit"
+		);
+
+		pallet_asset_registry::migration::v1::migrate::<Runtime>()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
+		frame_support::log::info!("PostMigrate Asset Registry Pallet start");
+		pallet_asset_registry::migration::v1::post_migrate::<Runtime>();
+		frame_support::log::info!("PostMigrate Asset Registry Pallet end");
+		Ok(())
 	}
 }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -25,14 +25,14 @@ pallet-marketplace = { path = '../../pallets/marketplace', default-features = fa
 pallet-xyk-liquidity-mining = { path = "../../pallets/xyk-liquidity-mining", default-features=false}
 
 # Warehouse dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 # Substrate dependencies
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common-runtime"
-version = "2.3.9"
+version = "2.3.10"
 authors = ["GalacticCouncil"]
 edition = "2021"
 homepage = "https://github.com/galacticcouncil/Basilisk-node"

--- a/runtime/testing-basilisk/Cargo.toml
+++ b/runtime/testing-basilisk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing-basilisk-runtime"
-version = "95.0.0"
+version = "96.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 homepage = "https://github.com/galacticcouncil/Basilisk-node"

--- a/runtime/testing-basilisk/Cargo.toml
+++ b/runtime/testing-basilisk/Cargo.toml
@@ -38,18 +38,18 @@ pallet-tips = { git = "https://github.com/paritytech/substrate", branch = "polka
 pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 
 # Warehouse dependencies
-hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false}
-pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
-pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "f64f50255965a1177d28bbc969a371013584bbdd", default-features = false }
+hydradx-traits = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-relaychain-info = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-transaction-multi-payment = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false}
+pallet-asset-registry = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+hydradx-adapters = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-nft = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-currencies = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-transaction-pause = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-route-executor = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+warehouse-liquidity-mining = { package="pallet-liquidity-mining", git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-ema-oracle = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
+pallet-duster = { git = "https://github.com/galacticcouncil/warehouse", rev = "d6a78b5d51bc8af525d2b8f856efcfce2159e334", default-features = false }
 
 # collator support
 pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.38", default-features = false }

--- a/runtime/testing-basilisk/src/lib.rs
+++ b/runtime/testing-basilisk/src/lib.rs
@@ -134,7 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("testing-basilisk"),
 	impl_name: create_runtime_str!("testing-basilisk"),
 	authoring_version: 1,
-	spec_version: 95,
+	spec_version: 96,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Add a migration for the asset registry that removes `locked` and introduces `xcm_rate_limit`.

https://github.com/galacticcouncil/warehouse/pull/209

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if necessary.
- [ ] I have added tests to cover my changes, regression test if fixing an issue.
- [ ] This is a breaking change.
