### PR TITLE
test: spot price tests fixed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7217,7 +7217,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xyk"
-version = "6.2.5"
+version = "6.2.6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-xyk'
-version = "6.2.5"
+version = "6.2.6"
 description = 'XYK automated market maker'
 authors = ['GalacticCouncil']
 edition = '2021'

--- a/pallets/xyk/src/tests/spot_price.rs
+++ b/pallets/xyk/src/tests/spot_price.rs
@@ -28,7 +28,7 @@ fn spot_price_provider_should_return_correct_price_when_pool_exists() {
 
 			let price = XYKSpotPrice::<Test>::spot_price(asset_a, asset_b);
 
-			assert_eq!(price, Some(Price::from_float(0.4)));
+			assert_eq!(price, Some(Price::from_float(2.5))); // 99_000 / 39_600 = 2.5
 		});
 }
 
@@ -72,7 +72,7 @@ fn spot_price_provider_should_return_none_when_asset_reserve_is_zero() {
 			assert_ok!(Currency::set_balance(
 				RawOrigin::Root.into(),
 				pool_account,
-				asset_a,
+				asset_b,
 				0u128,
 				0u128
 			));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- We are using semantinc pull request to make our lives easier -->
<!--- Please use prefixes for the title and use ! before : if breaking like below -->
<!--- build: ci: docs: feat: perf: refactor: fix: style: test: refactor!: -->

Tests were broken on master, probably due to merging #614 
This adjusts the tests to the new asset order for the `spot_price` function.
