### PR TITLE
feat(Marketplace): bounded storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,15 +614,15 @@ dependencies = [
 name = "basilisk-runtime"
 version = "103.0.0"
 dependencies = [
-    "cumulus-pallet-aura-ext",
-    "cumulus-pallet-dmp-queue",
-    "cumulus-pallet-parachain-system",
-    "cumulus-pallet-xcm",
-    "cumulus-pallet-xcmp-queue",
-    "cumulus-primitives-core",
-    "cumulus-primitives-parachain-inherent",
-    "cumulus-primitives-timestamp",
-    "cumulus-primitives-utility",
+ "cumulus-pallet-aura-ext",
+ "cumulus-pallet-dmp-queue",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-xcm",
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-timestamp",
+ "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",
@@ -6495,7 +6495,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-marketplace"
-version = "5.0.14"
+version = "5.0.15"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/marketplace/Cargo.toml
+++ b/pallets/marketplace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-marketplace"
-version = "5.0.14"
+version = "5.0.15"
 authors = ["GalacticCoucil"]
 description = "The marketplace for trading NFTs"
 edition = "2018"

--- a/pallets/marketplace/src/lib.rs
+++ b/pallets/marketplace/src/lib.rs
@@ -62,7 +62,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	#[pallet::storage]

--- a/pallets/marketplace/src/types.rs
+++ b/pallets/marketplace/src/types.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use scale_info::TypeInfo;
 
-#[derive(Encode, Decode, Eq, Copy, PartialEq, Clone, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Eq, Copy, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct Offer<AccountId, Balance, BlockNumber> {
 	/// User who made the offer
@@ -16,7 +16,7 @@ pub struct Offer<AccountId, Balance, BlockNumber> {
 	pub(super) expires: BlockNumber,
 }
 
-#[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct Royalty<AccountId> {
 	/// The user account which receives the royalty


### PR DESCRIPTION
This PR removes `without_storage_info` from the Marketplace pallet.