### PR TITLE
[chore] Configure Defer Duration

### DIFF
--- a/runtime/basilisk/src/xcm.rs
+++ b/runtime/basilisk/src/xcm.rs
@@ -269,8 +269,25 @@ impl pallet_xcm::Config for Runtime {
 	type RemoteLockConsumerIdentifier = ();
 }
 
+#[test]
+fn defer_duration_configuration() {
+	use sp_runtime::{traits::One, FixedPointNumber, FixedU128};
+	/// Calculate the configuration value for the defer duration based on the desired defer duration and
+	/// the threshold percentage when to start deferring.
+	/// - `defer_by`: the desired defer duration when reaching the rate limit
+	/// - `a``: the fraction of the rate limit where we start deferring, e.g. 0.9
+	fn defer_duration(defer_by: u32, a: FixedU128) -> u32 {
+		assert!(a < FixedU128::one());
+		// defer_by * a / (1 - a)
+		(FixedU128::one() / (FixedU128::one() - a)).saturating_mul_int(a.saturating_mul_int(defer_by))
+	}
+	assert_eq!(
+		defer_duration(600 * 4, FixedU128::from_rational(9, 10)),
+		DeferDuration::get()
+	);
+}
 parameter_types! {
-	pub DeferDuration: RelayChainBlockNumber = 100; // 10 min
+	pub DeferDuration: RelayChainBlockNumber = 600 * 36; // 36 hours
 	pub MaxDeferDuration: RelayChainBlockNumber = 600 * 24 * 10; // 10 days
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Configure the defer duration to 36 hours. This value is derived based on a desired effective defer duration of 4h as well as a defer boundary of 0.9 (start deferring at 90% of the desired rate limit boundary value), i.e. if we want to ensure that 200000$ are deferred by 4h, we configure 36h as the defer duration and 0.9*200000 = 180000 as the rate limit in the registry.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation if necessary.
- [x] I have added tests to cover my changes, regression test if fixing an issue.
- [x] This is a breaking change.
