### PR TITLE
ci: add write permission for version-check job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -96,6 +96,8 @@ jobs:
 
   version-check:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     outputs:
       runtime-upgraded: ${{ steps.check-runtime.outputs.upgraded }}
     steps:


### PR DESCRIPTION
Should fix the error from version-check job:
Error: Resource not accessible by integration