### PR TITLE
Add HashedDescription XCM converter and remove TinkernetMultisig configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,6 @@ dependencies = [
  "orml-unknown-tokens",
  "orml-vesting",
  "orml-xcm",
- "orml-xcm-builder-kusama",
  "orml-xcm-support",
  "orml-xtokens",
  "pallet-asset-registry",
@@ -6279,26 +6278,6 @@ dependencies = [
  "scale-info",
  "sp-std",
  "staging-xcm",
-]
-
-[[package]]
-name = "orml-xcm-builder-kusama"
-version = "1.0.0"
-source = "git+https://github.com/open-web3-stack/orml-xcm-builder?rev=32f0b3f1cbe77d4d330e07c7d4fcc3ebd669db77#32f0b3f1cbe77d4d330e07c7d4fcc3ebd669db77"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-weights",
- "staging-xcm",
- "staging-xcm-executor",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,9 +223,6 @@ orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-libra
 orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "b3694e631df7f1ca16b1973122937753fcdee9d4", default-features = false }
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "b3694e631df7f1ca16b1973122937753fcdee9d4", default-features = false }
 
-# InvArch Tinkernet Multisig dependencies
-orml-xcm-builder-kusama = { git = "https://github.com/open-web3-stack/orml-xcm-builder", rev = "32f0b3f1cbe77d4d330e07c7d4fcc3ebd669db77", default-features = false }
-
 
 [patch."https://github.com/paritytech/polkadot-sdk"]
 frame-benchmarking = { git = "https://github.com/galacticcouncil/polkadot-sdk", rev = "062d92eae0f3bb9908faf2d4e241eef17368b9d3" }

--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -125,9 +125,6 @@ sp-staking = { workspace = true }
 sp-trie = { workspace = true }
 sp-io = { workspace = true }
 
-# InvArch Tinkernet Multisig dependencies
-orml-xcm-builder-kusama = { workspace = true }
-
 [features]
 default = ["std"]
 runtime-benchmarks = [


### PR DESCRIPTION
This PR adds the common XCM location converter HashedDescription, which is used across the ecosystem, to Basilisk.

Since the current Polkadot SDK version in use does not contain the `DescribeBodyTerminal` config, it is also temporarily pulled locally into `xcm.rs`, to be removed once the runtime is upgraded to polkadot-v1.2.0, which [adds it to DescribeAllTerminal](https://github.com/paritytech/polkadot-sdk/blob/release-polkadot-v1.2.0/polkadot/xcm/xcm-builder/src/location_conversion.rs#L104).

For reference, chains using HashedDescription include the [relay chain](https://github.com/polkadot-fellows/runtimes/blob/main/relay/kusama/src/xcm_config.rs#L76) and system parachains like the [Asset Hub](https://github.com/polkadot-fellows/runtimes/blob/main/system-parachains/asset-hubs/asset-hub-kusama/src/xcm_config.rs#L93).
