### PR TITLE
fix: Update TechComm origins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "basilisk-runtime"
-version = "116.0.0"
+version = "117.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilisk-runtime"
-version = "116.0.0"
+version = "117.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 homepage = "https://github.com/galacticcouncil/Basilisk-node"

--- a/runtime/basilisk/src/governance/mod.rs
+++ b/runtime/basilisk/src/governance/mod.rs
@@ -29,6 +29,7 @@ use frame_support::{
 	PalletId,
 };
 use frame_system::{EnsureRoot, EnsureRootWithSuccess};
+use pallet_collective::EnsureProportionAtLeast;
 use primitives::constants::{currency::DOLLARS, time::DAYS};
 use sp_arithmetic::Perbill;
 use sp_runtime::{traits::IdentityLookup, DispatchError};
@@ -37,6 +38,8 @@ pub mod origins;
 mod tracks;
 // Old governance configurations.
 pub mod old;
+
+pub type TechCommitteeMajority = EnsureProportionAtLeast<AccountId, TechnicalCollective, 1, 2>;
 
 parameter_types! {
 	pub const TechnicalMotionDuration: BlockNumber = 5 * DAYS;
@@ -84,7 +87,7 @@ impl pallet_whitelist::Config for Runtime {
 	type WeightInfo = weights::pallet_whitelist::WeightInfo<Self>;
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
-	type WhitelistOrigin = EnsureRoot<Self::AccountId>;
+	type WhitelistOrigin = EitherOf<EnsureRoot<Self::AccountId>, TechCommitteeMajority>;
 	type DispatchWhitelistedOrigin = EitherOf<EnsureRoot<Self::AccountId>, WhitelistedCaller>;
 	type Preimages = Preimage;
 }

--- a/runtime/basilisk/src/lib.rs
+++ b/runtime/basilisk/src/lib.rs
@@ -102,7 +102,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("basilisk"),
 	impl_name: create_runtime_str!("basilisk"),
 	authoring_version: 1,
-	spec_version: 116,
+	spec_version: 117,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/basilisk/src/system.rs
+++ b/runtime/basilisk/src/system.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 use super::*;
-use crate::governance::{old::MajorityTechCommitteeOrRoot, origins::GeneralAdmin, TreasuryAccount};
+use crate::governance::{origins::GeneralAdmin, TechCommitteeMajority, TreasuryAccount};
 
 use pallet_transaction_multi_payment::{DepositAll, TransferFees};
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
@@ -488,7 +488,7 @@ impl pallet_relaychain_info::Config for Runtime {
 
 impl pallet_transaction_pause::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type UpdateOrigin = MajorityTechCommitteeOrRoot;
+	type UpdateOrigin = EitherOf<EnsureRoot<Self::AccountId>, TechCommitteeMajority>;
 	type WeightInfo = weights::pallet_transaction_pause::BasiliskWeight<Runtime>;
 }
 


### PR DESCRIPTION
This PR refactors the TechnicalCommittee origins and enables it to post referenda to the whitelisted track