### PR TITLE
ci: new version of upload-artifact in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,12 +38,12 @@ jobs:
       - name: Version info
         run: ./target/release/basilisk --version
       - name: Upload release binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: basilisk
           path: target/release/basilisk
       - name: Upload release wasm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: basilisk_runtime.compact.compressed.wasm
           path: target/release/basilisk_runtime.compact.compressed.wasm


### PR DESCRIPTION
fixes the following error from the CI: `Error: This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v2. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/`