### PR TITLE
feat: Slot-based collators and RelayParentOffset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,7 @@ dependencies = [
  "pallet-migrations",
  "pallet-multisig",
  "pallet-nft",
+ "pallet-parameters 1.0.0",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-referenda",
@@ -8860,6 +8861,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-parameters"
+version = "1.0.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-preimage"
 version = "41.0.0"
 source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-7-patch#fcda9c2d27456e4d1399446bef179100d280d0d0"
@@ -12153,7 +12167,7 @@ dependencies = [
  "pallet-multisig",
  "pallet-nis",
  "pallet-offences",
- "pallet-parameters",
+ "pallet-parameters 0.12.0",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-ranked-collective",
@@ -17684,7 +17698,7 @@ dependencies = [
  "pallet-nomination-pools-runtime-api",
  "pallet-offences",
  "pallet-offences-benchmarking",
- "pallet-parameters",
+ "pallet-parameters 0.12.0",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-recovery",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basilisk"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "basilisk-runtime",
  "clap",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "basilisk-runtime"
-version = "129.0.0"
+version = "130.0.0"
 dependencies = [
  "basilisk-adapters",
  "basilisk-math",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12334,7 +12334,7 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "runtime-integration-tests"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "basilisk-runtime",
  "basilisk-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ panic = 'unwind'
 members = [
   'math',
   'node',
+  'pallets/parameters',
   'runtime/basilisk',
   'pallets/marketplace',
   'pallets/asset-registry',
@@ -56,6 +57,7 @@ pallet-marketplace = { path = "pallets/marketplace", default-features = false}
 pallet-asset-registry = { path = "pallets/asset-registry", default-features = false}
 pallet-ema-oracle = { path = "pallets/ema-oracle", default-features = false}
 pallet-lbp = { path = "pallets/lbp", default-features = false }
+pallet-parameters = { path = "pallets/parameters", default-features = false }
 pallet-route-executor = { path = "pallets/route-executor", default-features = false }
 pallet-transaction-multi-payment = { path = "pallets/transaction-multi-payment", default-features = false }
 pallet-xyk = { path = "pallets/xyk", default-features = false }
@@ -596,4 +598,3 @@ westend-runtime = { git = "https://github.com/galacticcouncil/polkadot-sdk", bra
 cumulus-client-pov-recovery = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-7-patch" }
 cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-7-patch" }
 cumulus-relay-chain-rpc-interface = { git = "https://github.com/galacticcouncil/polkadot-sdk", branch = "polkadot-stable2506-7-patch" }
-

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-integration-tests"
-version = "1.2.0"
+version = "1.2.1"
 description = "Integration tests"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/integration-tests/src/kusama_test_net.rs
+++ b/integration-tests/src/kusama_test_net.rs
@@ -448,6 +448,10 @@ pub mod basilisk {
 				safe_xcm_version: Some(5),
 				..Default::default()
 			},
+			parameters: basilisk_runtime::ParametersConfig {
+				relay_parent_offset_override: true,
+				..Default::default()
+			},
 			multi_transaction_payment: basilisk_runtime::MultiTransactionPaymentConfig {
 				currencies: vec![(AUSD, Price::from_inner(462_962_963_000_u128))], //0.000_000_462_962_963
 				account_currencies: vec![],
@@ -514,6 +518,10 @@ pub mod other_parachain {
 			},
 			polkadot_xcm: basilisk_runtime::PolkadotXcmConfig {
 				safe_xcm_version: Some(5),
+				..Default::default()
+			},
+			parameters: basilisk_runtime::ParametersConfig {
+				relay_parent_offset_override: true,
 				..Default::default()
 			},
 			multi_transaction_payment: basilisk_runtime::MultiTransactionPaymentConfig {

--- a/launch-configs/zombienet/local.json
+++ b/launch-configs/zombienet/local.json
@@ -34,6 +34,16 @@
         "name": "bob",
         "ws_port": 9955,
         "validator": true
+      },
+      {
+        "name": "charlie",
+        "ws_port": 9966,
+        "validator": true
+      },
+      {
+        "name": "dave",
+        "ws_port": 9977,
+        "validator": true
       }
     ]
   },

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilisk"
-version = "19.1.0"
+version = "20.0.0"
 description = "Basilisk node"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/node/src/chain_spec/local.rs
+++ b/node/src/chain_spec/local.rs
@@ -102,6 +102,8 @@ pub fn parachain_config() -> Result<ChainSpec, String> {
 		],
 		// parachain ID
 		PARA_ID.into(),
+		// is_testnet
+		true,
 	);
 
 	let chain_spec = ChainSpec::builder(

--- a/node/src/chain_spec/local.rs
+++ b/node/src/chain_spec/local.rs
@@ -45,7 +45,7 @@ pub fn parachain_config() -> Result<ChainSpec, String> {
 		),
 		// endowed_accounts
 		vec![
-			(get_account_id_from_seed::<sr25519::Public>("Alice"), INITIAL_BALANCE),
+			(get_account_id_from_seed::<sr25519::Public>("Alice"), INITIAL_BALANCE * 20),
 			(get_account_id_from_seed::<sr25519::Public>("Bob"), INITIAL_BALANCE),
 			(get_account_id_from_seed::<sr25519::Public>("Charlie"), INITIAL_BALANCE),
 			(get_account_id_from_seed::<sr25519::Public>("Dave"), INITIAL_BALANCE),

--- a/node/src/chain_spec/local.rs
+++ b/node/src/chain_spec/local.rs
@@ -45,7 +45,10 @@ pub fn parachain_config() -> Result<ChainSpec, String> {
 		),
 		// endowed_accounts
 		vec![
-			(get_account_id_from_seed::<sr25519::Public>("Alice"), INITIAL_BALANCE * 20),
+			(
+				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				INITIAL_BALANCE * 20,
+			),
 			(get_account_id_from_seed::<sr25519::Public>("Bob"), INITIAL_BALANCE),
 			(get_account_id_from_seed::<sr25519::Public>("Charlie"), INITIAL_BALANCE),
 			(get_account_id_from_seed::<sr25519::Public>("Dave"), INITIAL_BALANCE),

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -88,6 +88,7 @@ pub fn parachain_genesis(
 	accepted_assets: Vec<(AssetId, Price)>, // (Asset id, Fallback price) - asset which fee can be paid with
 	token_balances: Vec<(AccountId, Vec<(AssetId, Balance)>)>,
 	parachain_id: ParaId,
+	is_testnet: bool,
 ) -> serde_json::Value {
 	serde_json::json!({
 		"system": {},
@@ -134,6 +135,9 @@ pub fn parachain_genesis(
 		"multiTransactionPayment": {
 			"currencies": accepted_assets,
 			"accountCurrencies": Vec::<(AccountId, AssetId)>::new(),
+		},
+		"parameters": {
+			"isTestnet": is_testnet,
 		},
 		"parachainInfo": {
 			"parachainId": parachain_id,

--- a/node/src/chain_spec/paseo.rs
+++ b/node/src/chain_spec/paseo.rs
@@ -81,6 +81,8 @@ pub fn _parachain_config_paseo() -> Result<ChainSpec, String> {
 		vec![],
 		// parachain ID
 		PARA_ID.into(),
+		// is_testnet
+		false,
 	);
 
 	let chain_spec = ChainSpec::builder(

--- a/node/src/chain_spec/rococo.rs
+++ b/node/src/chain_spec/rococo.rs
@@ -79,6 +79,8 @@ pub fn _parachain_config_rococo() -> Result<ChainSpec, String> {
 		vec![],
 		// parachain ID
 		PARA_ID.into(),
+		// is_testnet
+		false,
 	);
 
 	let chain_spec = ChainSpec::builder(

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -31,9 +31,7 @@ use basilisk_runtime::{
 
 // Cumulus Imports
 use cumulus_client_collator::service::CollatorService;
-use cumulus_client_consensus_aura::collators::slot_based::{
-	SlotBasedBlockImport, SlotBasedBlockImportHandle,
-};
+use cumulus_client_consensus_aura::collators::slot_based::{SlotBasedBlockImport, SlotBasedBlockImportHandle};
 use cumulus_client_consensus_common::ParachainBlockImport as TParachainBlockImport;
 use cumulus_client_consensus_proposer::Proposer;
 use cumulus_client_service::{
@@ -44,7 +42,7 @@ use cumulus_primitives_core::{
 	relay_chain::{CollatorPair, ValidationCode},
 	ParaId,
 };
-use cumulus_relay_chain_interface::{OverseerHandle, RelayChainInterface};
+use cumulus_relay_chain_interface::RelayChainInterface;
 
 // Substrate Imports
 use sc_client_api::Backend;
@@ -68,11 +66,8 @@ type ParachainClient = TFullClient<
 
 type ParachainBackend = TFullBackend<Block>;
 
-type ParachainBlockImport = TParachainBlockImport<
-	Block,
-	SlotBasedBlockImport<Block, Arc<ParachainClient>, ParachainClient>,
-	ParachainBackend,
->;
+type ParachainBlockImport =
+	TParachainBlockImport<Block, SlotBasedBlockImport<Block, Arc<ParachainClient>, ParachainClient>, ParachainBackend>;
 
 /// Starts a `ServiceBuilder` for a full service.
 ///
@@ -87,7 +82,12 @@ pub fn new_partial(
 		(),
 		sc_consensus::DefaultImportQueue<Block>,
 		sc_transaction_pool::TransactionPoolHandle<Block, ParachainClient>,
-		(ParachainBlockImport, SlotBasedBlockImportHandle<Block>, Option<Telemetry>, Option<TelemetryWorkerHandle>),
+		(
+			ParachainBlockImport,
+			SlotBasedBlockImportHandle<Block>,
+			Option<Telemetry>,
+			Option<TelemetryWorkerHandle>,
+		),
 	>,
 	sc_service::Error,
 > {
@@ -145,8 +145,7 @@ pub fn new_partial(
 		.build(),
 	);
 
-	let (slot_based_block_import, block_import_handle) =
-		SlotBasedBlockImport::new(client.clone(), client.clone());
+	let (slot_based_block_import, block_import_handle) = SlotBasedBlockImport::new(client.clone(), client.clone());
 	let block_import = ParachainBlockImport::new(slot_based_block_import, backend.clone());
 
 	let import_queue = build_import_queue(
@@ -348,7 +347,6 @@ async fn start_node_impl(
 			relay_chain_slot_duration,
 			para_id,
 			collator_key.expect("Command line arguments do not allow this. qed"),
-			overseer_handle,
 			announce_block,
 		)?;
 	}
@@ -399,7 +397,6 @@ fn start_consensus(
 	relay_chain_slot_duration: Duration,
 	para_id: ParaId,
 	collator_key: CollatorPair,
-	_overseer_handle: OverseerHandle,
 	announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
 ) -> Result<(), sc_service::Error> {
 	use cumulus_client_consensus_aura::collators::slot_based::{self as slot_based, Params as SlotBasedParams};
@@ -429,7 +426,10 @@ fn start_consensus(
 		para_backend: backend.clone(),
 		relay_client: relay_chain_interface,
 		code_hash_provider: move |block_hash| {
-			client_for_aura.code_at(block_hash).ok().map(|c| ValidationCode::from(c).hash())
+			client_for_aura
+				.code_at(block_hash)
+				.ok()
+				.map(|c| ValidationCode::from(c).hash())
 		},
 		keystore,
 		collator_key,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -31,6 +31,9 @@ use basilisk_runtime::{
 
 // Cumulus Imports
 use cumulus_client_collator::service::CollatorService;
+use cumulus_client_consensus_aura::collators::slot_based::{
+	SlotBasedBlockImport, SlotBasedBlockImportHandle,
+};
 use cumulus_client_consensus_common::ParachainBlockImport as TParachainBlockImport;
 use cumulus_client_consensus_proposer::Proposer;
 use cumulus_client_service::{
@@ -65,7 +68,11 @@ type ParachainClient = TFullClient<
 
 type ParachainBackend = TFullBackend<Block>;
 
-type ParachainBlockImport = TParachainBlockImport<Block, Arc<ParachainClient>, ParachainBackend>;
+type ParachainBlockImport = TParachainBlockImport<
+	Block,
+	SlotBasedBlockImport<Block, Arc<ParachainClient>, ParachainClient>,
+	ParachainBackend,
+>;
 
 /// Starts a `ServiceBuilder` for a full service.
 ///
@@ -80,7 +87,7 @@ pub fn new_partial(
 		(),
 		sc_consensus::DefaultImportQueue<Block>,
 		sc_transaction_pool::TransactionPoolHandle<Block, ParachainClient>,
-		(ParachainBlockImport, Option<Telemetry>, Option<TelemetryWorkerHandle>),
+		(ParachainBlockImport, SlotBasedBlockImportHandle<Block>, Option<Telemetry>, Option<TelemetryWorkerHandle>),
 	>,
 	sc_service::Error,
 > {
@@ -138,7 +145,9 @@ pub fn new_partial(
 		.build(),
 	);
 
-	let block_import = ParachainBlockImport::new(client.clone(), backend.clone());
+	let (slot_based_block_import, block_import_handle) =
+		SlotBasedBlockImport::new(client.clone(), client.clone());
+	let block_import = ParachainBlockImport::new(slot_based_block_import, backend.clone());
 
 	let import_queue = build_import_queue(
 		client.clone(),
@@ -156,7 +165,7 @@ pub fn new_partial(
 		task_manager,
 		transaction_pool,
 		select_chain: (),
-		other: (block_import, telemetry, telemetry_worker_handle),
+		other: (block_import, block_import_handle, telemetry, telemetry_worker_handle),
 	})
 }
 
@@ -174,7 +183,7 @@ async fn start_node_impl(
 	let parachain_config = prepare_node_config(parachain_config);
 
 	let params = new_partial(&parachain_config)?;
-	let (block_import, mut telemetry, telemetry_worker_handle) = params.other;
+	let (block_import, block_import_handle, mut telemetry, telemetry_worker_handle) = params.other;
 
 	let prometheus_registry = parachain_config.prometheus_registry().cloned();
 	let net_config = sc_network::config::FullNetworkConfiguration::<_, _, sc_network::NetworkWorker<Block, Hash>>::new(
@@ -329,6 +338,7 @@ async fn start_node_impl(
 			client.clone(),
 			backend.clone(),
 			block_import,
+			block_import_handle,
 			prometheus_registry.as_ref(),
 			telemetry.as_ref().map(|t| t.handle()),
 			&task_manager,
@@ -379,6 +389,7 @@ fn start_consensus(
 	client: Arc<ParachainClient>,
 	backend: Arc<ParachainBackend>,
 	block_import: ParachainBlockImport,
+	block_import_handle: SlotBasedBlockImportHandle<Block>,
 	prometheus_registry: Option<&Registry>,
 	telemetry: Option<TelemetryHandle>,
 	task_manager: &TaskManager,
@@ -388,13 +399,10 @@ fn start_consensus(
 	relay_chain_slot_duration: Duration,
 	para_id: ParaId,
 	collator_key: CollatorPair,
-	overseer_handle: OverseerHandle,
+	_overseer_handle: OverseerHandle,
 	announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
 ) -> Result<(), sc_service::Error> {
-	use cumulus_client_consensus_aura::collators::lookahead::{self as aura, Params as AuraParams};
-
-	// NOTE: because we use Aura here explicitly, we can use `CollatorSybilResistance::Resistant`
-	// when starting the network.
+	use cumulus_client_consensus_aura::collators::slot_based::{self as slot_based, Params as SlotBasedParams};
 
 	let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
 		task_manager.spawn_handle(),
@@ -413,27 +421,32 @@ fn start_consensus(
 		client.clone(),
 	);
 
-	let params = AuraParams {
+	let client_for_aura = client.clone();
+	let params = SlotBasedParams {
 		create_inherent_data_providers: move |_, ()| async move { Ok(()) },
 		block_import,
 		para_client: client.clone(),
 		para_backend: backend.clone(),
 		relay_client: relay_chain_interface,
-		code_hash_provider: move |block_hash| client.code_at(block_hash).ok().map(|c| ValidationCode::from(c).hash()),
+		code_hash_provider: move |block_hash| {
+			client_for_aura.code_at(block_hash).ok().map(|c| ValidationCode::from(c).hash())
+		},
 		keystore,
 		collator_key,
 		para_id,
-		overseer_handle,
-		relay_chain_slot_duration,
 		proposer,
 		collator_service,
-		authoring_duration: Duration::from_millis(1500),
+		authoring_duration: Duration::from_millis(2000),
 		reinitialize: false,
-		max_pov_percentage: None, // Defaults to 85% of max PoV size (safe default)
+		slot_offset: Duration::from_secs(1),
+		block_import_handle,
+		spawner: task_manager.spawn_handle(),
+		relay_chain_slot_duration,
+		export_pov: None,
+		max_pov_percentage: None,
 	};
 
-	let fut = aura::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _, _, _>(params);
-	task_manager.spawn_essential_handle().spawn("aura", None, fut);
+	slot_based::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _, _, _, _>(params);
 
 	Ok(())
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -436,7 +436,7 @@ fn start_consensus(
 		para_id,
 		proposer,
 		collator_service,
-		authoring_duration: Duration::from_millis(2000),
+		authoring_duration: Duration::from_millis(1500),
 		reinitialize: false,
 		slot_offset: Duration::from_secs(1),
 		block_import_handle,

--- a/pallets/parameters/Cargo.toml
+++ b/pallets/parameters/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "pallet-parameters"
+version = "1.0.0"
+authors = ["GalacticCouncil"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://github.com/galacticcouncil/Basilisk-node"
+repository = "https://github.com/galacticcouncil/Basilisk-node"
+description = "Pallet for storing runtime parameters"
+
+[dependencies]
+codec = { workspace = true, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+
+[dev-dependencies]
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "scale-info/std",
+    "frame-support/std",
+    "frame-system/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/pallets/parameters/src/lib.rs
+++ b/pallets/parameters/src/lib.rs
@@ -1,0 +1,53 @@
+// This file is part of Basilisk-node.
+//
+// Copyright (C) 2020-2023  Intergalactic, Limited (GIB).
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+pub use pallet::*;
+
+use frame_support::pallet_prelude::*;
+use core::marker::PhantomData;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::storage]
+	#[pallet::getter(fn relay_parent_offset_override)]
+	pub type RelayParentOffsetOverride<T> = StorageValue<_, bool, ValueQuery>;
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		pub relay_parent_offset_override: bool,
+		pub _phantom: PhantomData<T>,
+	}
+
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			Self {
+				relay_parent_offset_override: false,
+				_phantom: PhantomData,
+			}
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
+		fn build(&self) {
+			RelayParentOffsetOverride::<T>::put(self.relay_parent_offset_override);
+		}
+	}
+}

--- a/pallets/parameters/src/lib.rs
+++ b/pallets/parameters/src/lib.rs
@@ -26,11 +26,16 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::storage]
+	#[pallet::getter(fn is_testnet)]
+	pub type IsTestnet<T> = StorageValue<_, bool, ValueQuery>;
+
+	#[pallet::storage]
 	#[pallet::getter(fn relay_parent_offset_override)]
 	pub type RelayParentOffsetOverride<T> = StorageValue<_, bool, ValueQuery>;
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
+		pub is_testnet: bool,
 		pub relay_parent_offset_override: bool,
 		pub _phantom: PhantomData<T>,
 	}
@@ -38,6 +43,7 @@ pub mod pallet {
 	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self {
 			Self {
+				is_testnet: false,
 				relay_parent_offset_override: false,
 				_phantom: PhantomData,
 			}
@@ -47,6 +53,7 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
+			IsTestnet::<T>::put(self.is_testnet);
 			RelayParentOffsetOverride::<T>::put(self.relay_parent_offset_override);
 		}
 	}

--- a/pallets/parameters/src/lib.rs
+++ b/pallets/parameters/src/lib.rs
@@ -12,8 +12,8 @@ mod tests;
 
 pub use pallet::*;
 
-use frame_support::pallet_prelude::*;
 use core::marker::PhantomData;
+use frame_support::pallet_prelude::*;
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/parameters/src/mock.rs
+++ b/pallets/parameters/src/mock.rs
@@ -1,0 +1,61 @@
+use crate as pallet_parameters;
+use frame_support::{construct_runtime, traits::Everything};
+use frame_system as system;
+use sp_core::H256;
+use sp_runtime::{traits::BlakeTwo256, BuildStorage};
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+construct_runtime!(
+	pub enum Test {
+		System: frame_system,
+		Parameters: pallet_parameters,
+	}
+);
+
+impl pallet_parameters::Config for Test {}
+
+impl system::Config for Test {
+	type BaseCallFilter = Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeTask = RuntimeTask;
+	type Nonce = u64;
+	type Block = Block;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = sp_runtime::traits::IdentityLookup<Self::AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = frame_support::traits::ConstU64<250>;
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = frame_support::traits::ConstU16<63>;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+	type ExtensionsWeightInfo = ();
+}
+
+#[derive(Default)]
+pub struct ExtBuilder;
+
+impl ExtBuilder {
+	pub fn build(self) -> sp_io::TestExternalities {
+		let storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+		let mut ext: sp_io::TestExternalities = storage.into();
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}

--- a/pallets/parameters/src/tests.rs
+++ b/pallets/parameters/src/tests.rs
@@ -2,14 +2,14 @@ use crate::{mock::*, Pallet as Parameters, RelayParentOffsetOverride};
 
 #[test]
 fn relay_parent_offset_override_is_false_by_default() {
-	ExtBuilder::default().build().execute_with(|| {
+	ExtBuilder.build().execute_with(|| {
 		assert!(!Parameters::<Test>::relay_parent_offset_override());
 	});
 }
 
 #[test]
 fn relay_parent_offset_override_can_be_read_from_storage() {
-	ExtBuilder::default().build().execute_with(|| {
+	ExtBuilder.build().execute_with(|| {
 		RelayParentOffsetOverride::<Test>::put(true);
 		assert!(Parameters::<Test>::relay_parent_offset_override());
 	});

--- a/pallets/parameters/src/tests.rs
+++ b/pallets/parameters/src/tests.rs
@@ -1,0 +1,16 @@
+use crate::{mock::*, Pallet as Parameters, RelayParentOffsetOverride};
+
+#[test]
+fn relay_parent_offset_override_is_false_by_default() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert!(!Parameters::<Test>::relay_parent_offset_override());
+	});
+}
+
+#[test]
+fn relay_parent_offset_override_can_be_read_from_storage() {
+	ExtBuilder::default().build().execute_with(|| {
+		RelayParentOffsetOverride::<Test>::put(true);
+		assert!(Parameters::<Test>::relay_parent_offset_override());
+	});
+}

--- a/pallets/parameters/src/tests.rs
+++ b/pallets/parameters/src/tests.rs
@@ -1,4 +1,19 @@
-use crate::{mock::*, Pallet as Parameters, RelayParentOffsetOverride};
+use crate::{mock::*, IsTestnet, Pallet as Parameters, RelayParentOffsetOverride};
+
+#[test]
+fn is_testnet_is_false_by_default() {
+	ExtBuilder.build().execute_with(|| {
+		assert!(!Parameters::<Test>::is_testnet());
+	});
+}
+
+#[test]
+fn is_testnet_can_be_read_from_storage() {
+	ExtBuilder.build().execute_with(|| {
+		IsTestnet::<Test>::put(true);
+		assert!(Parameters::<Test>::is_testnet());
+	});
+}
 
 #[test]
 fn relay_parent_offset_override_is_false_by_default() {

--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilisk-runtime"
-version = "129.0.0"
+version = "130.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 homepage = "https://github.com/galacticcouncil/Basilisk-node"

--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -56,6 +56,7 @@ pallet-duster = { workspace = true }
 pallet-collator-rewards = { workspace = true }
 pallet-xyk = { workspace = true }
 pallet-lbp = { workspace = true }
+pallet-parameters = { workspace = true }
 pallet-broadcast = { workspace = true }
 pallet-staking = { workspace = true }
 
@@ -235,6 +236,7 @@ std = [
     "pallet-transaction-multi-payment/std",
     "pallet-transaction-payment-rpc-runtime-api/std",
     "pallet-lbp/std",
+    "pallet-parameters/std",
     "pallet-utility/std",
     "pallet-xyk-liquidity-mining/std",
     "pallet-broadcast/std",
@@ -320,6 +322,7 @@ try-runtime= [
     "pallet-xyk/try-runtime",
     "pallet-duster/try-runtime",
     "pallet-lbp/try-runtime",
+    "pallet-parameters/try-runtime",
     "pallet-nft/try-runtime",
     "pallet-transaction-multi-payment/try-runtime",
     "pallet-relaychain-info/try-runtime",

--- a/runtime/basilisk/src/apis.rs
+++ b/runtime/basilisk/src/apis.rs
@@ -290,6 +290,12 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl cumulus_primitives_core::RelayParentOffsetApi<Block> for Runtime {
+		fn relay_parent_offset() -> u32 {
+			RELAY_PARENT_OFFSET
+		}
+	}
+
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {
 		fn benchmark_metadata(extra: bool) -> (

--- a/runtime/basilisk/src/apis.rs
+++ b/runtime/basilisk/src/apis.rs
@@ -296,6 +296,15 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl cumulus_primitives_core::GetCoreSelectorApi<Block> for Runtime {
+		fn core_selector() -> (
+			cumulus_primitives_core::CoreSelector,
+			cumulus_primitives_core::ClaimQueueOffset,
+		) {
+			ParachainSystem::core_selector()
+		}
+	}
+
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {
 		fn benchmark_metadata(extra: bool) -> (

--- a/runtime/basilisk/src/apis.rs
+++ b/runtime/basilisk/src/apis.rs
@@ -292,7 +292,7 @@ impl_runtime_apis! {
 
 	impl cumulus_primitives_core::RelayParentOffsetApi<Block> for Runtime {
 		fn relay_parent_offset() -> u32 {
-			RELAY_PARENT_OFFSET
+			RelayParentOffset::get()
 		}
 	}
 

--- a/runtime/basilisk/src/governance/mod.rs
+++ b/runtime/basilisk/src/governance/mod.rs
@@ -35,7 +35,7 @@ use sp_arithmetic::Perbill;
 use sp_runtime::{traits::IdentityLookup, DispatchError};
 
 pub mod origins;
-mod tracks;
+pub mod tracks;
 pub type TechCommitteeMajority = EnsureProportionAtLeast<AccountId, TechnicalCollective, 1, 2>;
 
 parameter_types! {

--- a/runtime/basilisk/src/governance/tracks.rs
+++ b/runtime/basilisk/src/governance/tracks.rs
@@ -151,12 +151,131 @@ const TRACKS_DATA: [Track<u16, Balance, BlockNumber>; 8] = [
 	},
 ];
 
+const TESTNET_TRACKS_DATA: [Track<u16, Balance, BlockNumber>; 8] = [
+	Track {
+		id: 0,
+		info: TrackInfo {
+			name: s("root"),
+			max_deciding: 3,
+			decision_deposit: 100_000_000 * UNITS,
+			prepare_period: 1,
+			decision_period: 7 * DAYS,
+			confirm_period: 1,
+			min_enactment_period: 1,
+			min_approval: APP_RECIP,
+			min_support: SUP_LINEAR,
+		},
+	},
+	Track {
+		id: 1,
+		info: TrackInfo {
+			name: s("whitelisted_caller"),
+			max_deciding: 3,
+			decision_deposit: 1_000_000 * UNITS,
+			prepare_period: 1,
+			decision_period: DAYS,
+			confirm_period: 1,
+			min_enactment_period: 1,
+			min_approval: APP_RECIP,
+			min_support: SUP_WHITELISTED_CALLER,
+		},
+	},
+	Track {
+		id: 2,
+		info: TrackInfo {
+			name: s("referendum_canceller"),
+			max_deciding: 10,
+			decision_deposit: 10_000_000 * UNITS,
+			prepare_period: 60 * MINUTES,
+			decision_period: 3 * DAYS,
+			confirm_period: 60 * MINUTES,
+			min_enactment_period: 10 * MINUTES,
+			min_approval: APP_LINEAR_FLAT,
+			min_support: SUP_FAST_RECIP,
+		},
+	},
+	Track {
+		id: 3,
+		info: TrackInfo {
+			name: s("referendum_killer"),
+			max_deciding: 10,
+			decision_deposit: 50_000_000 * UNITS,
+			prepare_period: 60 * MINUTES,
+			decision_period: 3 * DAYS,
+			confirm_period: 3 * HOURS,
+			min_enactment_period: 10 * MINUTES,
+			min_approval: APP_LINEAR_FLAT,
+			min_support: SUP_FAST_RECIP,
+		},
+	},
+	Track {
+		id: 4,
+		info: TrackInfo {
+			name: s("general_admin"),
+			max_deciding: 10,
+			decision_deposit: 10_000_000 * UNITS,
+			prepare_period: 1,
+			decision_period: 7 * DAYS,
+			confirm_period: 1,
+			min_enactment_period: 1,
+			min_approval: APP_RECIP,
+			min_support: SUP_RECIP,
+		},
+	},
+	Track {
+		id: 5,
+		info: TrackInfo {
+			name: s("treasurer"),
+			max_deciding: 10,
+			decision_deposit: 50_000_000 * UNITS,
+			prepare_period: 1,
+			decision_period: 7 * DAYS,
+			confirm_period: 1,
+			min_enactment_period: 1,
+			min_approval: APP_RECIP,
+			min_support: SUP_LINEAR,
+		},
+	},
+	Track {
+		id: 6,
+		info: TrackInfo {
+			name: s("spender"),
+			max_deciding: 10,
+			decision_deposit: 5_000_000 * UNITS,
+			prepare_period: 60 * MINUTES,
+			decision_period: 7 * DAYS,
+			confirm_period: 3 * HOURS,
+			min_enactment_period: 10 * MINUTES,
+			min_approval: APP_LINEAR,
+			min_support: SUP_RECIP,
+		},
+	},
+	Track {
+		id: 7,
+		info: TrackInfo {
+			name: s("tipper"),
+			max_deciding: 10,
+			decision_deposit: 500_000 * UNITS,
+			prepare_period: 60 * MINUTES,
+			decision_period: 7 * DAYS,
+			confirm_period: 3 * HOURS,
+			min_enactment_period: 10 * MINUTES,
+			min_approval: APP_LINEAR_FLAT,
+			min_support: SUP_FAST_RECIP,
+		},
+	},
+];
+
 pub struct TracksInfo;
 impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 	type Id = u16;
 	type RuntimeOrigin = <RuntimeOrigin as frame_support::traits::OriginTrait>::PalletsOrigin;
 	fn tracks() -> impl Iterator<Item = Cow<'static, Track<Self::Id, Balance, BlockNumber>>> {
-		TRACKS_DATA.iter().map(Cow::Borrowed)
+		if Parameters::is_testnet() {
+			TESTNET_TRACKS_DATA.iter().map(Cow::Borrowed)
+		} else {
+			TRACKS_DATA.iter().map(Cow::Borrowed)
+		}
 	}
 
 	fn track_for(id: &Self::RuntimeOrigin) -> Result<Self::Id, ()> {

--- a/runtime/basilisk/src/lib.rs
+++ b/runtime/basilisk/src/lib.rs
@@ -103,7 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("basilisk"),
 	impl_name: Cow::Borrowed("basilisk"),
 	authoring_version: 1,
-	spec_version: 129,
+	spec_version: 130,
 	impl_version: 0,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/basilisk/src/lib.rs
+++ b/runtime/basilisk/src/lib.rs
@@ -223,6 +223,7 @@ construct_runtime!(
 		// Note: 115 was used by rate limiter which is now removed
 		Broadcast: pallet_broadcast = 116,
 		MultiBlockMigrations: pallet_migrations = 117,
+		Parameters: pallet_parameters = 118,
 
 		EmaOracle: pallet_ema_oracle = 120,
 

--- a/runtime/basilisk/src/system.rs
+++ b/runtime/basilisk/src/system.rs
@@ -60,6 +60,8 @@ pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// Maximum number of blocks simultaneously accepted by the Runtime, not yet included into the
 /// relay chain.
 pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = 3;
+/// Build with an offset of 1 behind the relay chain best block.
+pub const RELAY_PARENT_OFFSET: u32 = 1;
 /// How many parachain blocks are processed by the relay chain per parent. Limits the number of
 /// blocks authored per slot.
 pub const BLOCK_PROCESSING_VELOCITY: u32 = 1;
@@ -481,7 +483,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ConsensusHook = ConsensusHook;
 	type WeightInfo = weights::cumulus_pallet_parachain_system::BasiliskWeight<Runtime>;
 	type SelectCore = cumulus_pallet_parachain_system::DefaultCoreSelector<Runtime>;
-	type RelayParentOffset = ConstU32<0>;
+	type RelayParentOffset = ConstU32<RELAY_PARENT_OFFSET>;
 }
 
 pub type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<

--- a/runtime/basilisk/src/system.rs
+++ b/runtime/basilisk/src/system.rs
@@ -57,14 +57,14 @@ pub const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_perthousand(25);
 /// by  Operational  extrinsics.
 pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
-/// Maximum number of blocks simultaneously accepted by the Runtime, not yet included into the
-/// relay chain.
-pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = 3;
 /// Build with an offset of 1 behind the relay chain best block.
 pub const RELAY_PARENT_OFFSET: u32 = 1;
 /// How many parachain blocks are processed by the relay chain per parent. Limits the number of
 /// blocks authored per slot.
 pub const BLOCK_PROCESSING_VELOCITY: u32 = 1;
+/// Maximum number of blocks simultaneously accepted by the Runtime, not yet included into the
+/// relay chain.
+pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = (3 + RELAY_PARENT_OFFSET) * BLOCK_PROCESSING_VELOCITY;
 /// Relay chain slot duration, in milliseconds.
 pub const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
 

--- a/runtime/basilisk/src/system.rs
+++ b/runtime/basilisk/src/system.rs
@@ -58,15 +58,27 @@ pub const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_perthousand(25);
 pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
 /// Build with an offset of 1 behind the relay chain best block.
-pub const RELAY_PARENT_OFFSET: u32 = 1;
+pub const DEFAULT_RELAY_PARENT_OFFSET: u32 = 1;
 /// How many parachain blocks are processed by the relay chain per parent. Limits the number of
 /// blocks authored per slot.
 pub const BLOCK_PROCESSING_VELOCITY: u32 = 1;
 /// Maximum number of blocks simultaneously accepted by the Runtime, not yet included into the
 /// relay chain.
-pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = (3 + RELAY_PARENT_OFFSET) * BLOCK_PROCESSING_VELOCITY;
+pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = (3 + DEFAULT_RELAY_PARENT_OFFSET) * BLOCK_PROCESSING_VELOCITY;
 /// Relay chain slot duration, in milliseconds.
 pub const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
+
+pub struct RelayParentOffset;
+
+impl Get<u32> for RelayParentOffset {
+	fn get() -> u32 {
+		if Parameters::relay_parent_offset_override() {
+			0
+		} else {
+			DEFAULT_RELAY_PARENT_OFFSET
+		}
+	}
+}
 
 pub struct BaseFilter;
 impl Contains<RuntimeCall> for BaseFilter {
@@ -205,6 +217,8 @@ impl pallet_migrations::Config for Runtime {
 	type MaxServiceWeight = MaxServiceWeight;
 	type WeightInfo = weights::pallet_migrations::BasiliskWeight<Runtime>;
 }
+
+impl pallet_parameters::Config for Runtime {}
 
 pub struct LogErrorAndForceUnstuck;
 impl frame_support::migrations::FailedMigrationHandler for LogErrorAndForceUnstuck {
@@ -483,7 +497,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ConsensusHook = ConsensusHook;
 	type WeightInfo = weights::cumulus_pallet_parachain_system::BasiliskWeight<Runtime>;
 	type SelectCore = cumulus_pallet_parachain_system::DefaultCoreSelector<Runtime>;
-	type RelayParentOffset = ConstU32<RELAY_PARENT_OFFSET>;
+	type RelayParentOffset = RelayParentOffset;
 }
 
 pub type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<

--- a/runtime/basilisk/src/tests.rs
+++ b/runtime/basilisk/src/tests.rs
@@ -2,9 +2,11 @@
 
 use crate::*;
 use codec::Encode;
+use cumulus_primitives_core::runtime_decl_for_relay_parent_offset_api::RelayParentOffsetApiV1;
 use frame_support::{
 	dispatch::{DispatchClass, GetDispatchInfo},
 	sp_runtime::{traits::Convert, BuildStorage, FixedPointNumber},
+	traits::Get,
 	weights::WeightToFee,
 };
 use pallet_transaction_payment::Multiplier;
@@ -154,5 +156,34 @@ fn metadata_api_implemented() {
 			panic!("Expected metadata V15");
 		};
 		assert!(!metadata.apis.is_empty());
+	});
+}
+
+#[test]
+fn relay_parent_offset_defaults_to_production_value() {
+	let mut ext: sp_io::TestExternalities = frame_system::GenesisConfig::<Runtime>::default()
+		.build_storage()
+		.unwrap()
+		.into();
+
+	ext.execute_with(|| {
+		assert_eq!(Parameters::relay_parent_offset_override(), false);
+		assert_eq!(RelayParentOffset::get(), DEFAULT_RELAY_PARENT_OFFSET);
+		assert_eq!(Runtime::relay_parent_offset(), DEFAULT_RELAY_PARENT_OFFSET);
+	});
+}
+
+#[test]
+fn relay_parent_offset_uses_override_when_enabled() {
+	let mut ext: sp_io::TestExternalities = frame_system::GenesisConfig::<Runtime>::default()
+		.build_storage()
+		.unwrap()
+		.into();
+
+	ext.execute_with(|| {
+		pallet_parameters::RelayParentOffsetOverride::<Runtime>::put(true);
+		assert_eq!(Parameters::relay_parent_offset_override(), true);
+		assert_eq!(RelayParentOffset::get(), 0);
+		assert_eq!(Runtime::relay_parent_offset(), 0);
 	});
 }

--- a/runtime/basilisk/src/tests.rs
+++ b/runtime/basilisk/src/tests.rs
@@ -9,6 +9,7 @@ use frame_support::{
 	traits::Get,
 	weights::WeightToFee,
 };
+use pallet_referenda::TracksInfo as _;
 use pallet_transaction_payment::Multiplier;
 use primitives::constants::{
 	currency::{CENTS, DOLLARS, MILLICENTS},
@@ -185,5 +186,43 @@ fn relay_parent_offset_uses_override_when_enabled() {
 		assert_eq!(Parameters::relay_parent_offset_override(), true);
 		assert_eq!(RelayParentOffset::get(), 0);
 		assert_eq!(Runtime::relay_parent_offset(), 0);
+	});
+}
+
+#[test]
+fn governance_tracks_default_to_normal_timings() {
+	let mut ext: sp_io::TestExternalities = frame_system::GenesisConfig::<Runtime>::default()
+		.build_storage()
+		.unwrap()
+		.into();
+
+	ext.execute_with(|| {
+		let root_track = governance::tracks::TracksInfo::tracks()
+			.find(|track| track.id == 0)
+			.expect("root track should exist");
+		assert_eq!(root_track.info.prepare_period, HOURS);
+		assert_eq!(root_track.info.confirm_period, 12 * HOURS);
+	});
+}
+
+#[test]
+fn governance_tracks_use_testnet_timings_when_enabled() {
+	let mut ext: sp_io::TestExternalities = frame_system::GenesisConfig::<Runtime>::default()
+		.build_storage()
+		.unwrap()
+		.into();
+
+	ext.execute_with(|| {
+		pallet_parameters::IsTestnet::<Runtime>::put(true);
+		let root_track = governance::tracks::TracksInfo::tracks()
+			.find(|track| track.id == 0)
+			.expect("root track should exist");
+		let general_admin_track = governance::tracks::TracksInfo::tracks()
+			.find(|track| track.id == 4)
+			.expect("general admin track should exist");
+		assert_eq!(root_track.info.prepare_period, 1);
+		assert_eq!(root_track.info.confirm_period, 1);
+		assert_eq!(general_admin_track.info.prepare_period, 1);
+		assert_eq!(general_admin_track.info.confirm_period, 1);
 	});
 }

--- a/runtime/basilisk/src/tests.rs
+++ b/runtime/basilisk/src/tests.rs
@@ -168,7 +168,7 @@ fn relay_parent_offset_defaults_to_production_value() {
 		.into();
 
 	ext.execute_with(|| {
-		assert_eq!(Parameters::relay_parent_offset_override(), false);
+		assert!(!Parameters::relay_parent_offset_override());
 		assert_eq!(RelayParentOffset::get(), DEFAULT_RELAY_PARENT_OFFSET);
 		assert_eq!(Runtime::relay_parent_offset(), DEFAULT_RELAY_PARENT_OFFSET);
 	});
@@ -183,7 +183,7 @@ fn relay_parent_offset_uses_override_when_enabled() {
 
 	ext.execute_with(|| {
 		pallet_parameters::RelayParentOffsetOverride::<Runtime>::put(true);
-		assert_eq!(Parameters::relay_parent_offset_override(), true);
+		assert!(Parameters::relay_parent_offset_override());
 		assert_eq!(RelayParentOffset::get(), 0);
 		assert_eq!(Runtime::relay_parent_offset(), 0);
 	});


### PR DESCRIPTION
This PR helps alleviate the bad UX around forks and build a stepping stone towards the migration to 2s blocktime:
* switches collators from lookahead towards slot-based authorship
* sets the RelayParentOffset to 1
* adds pallet-params with RelayParentOffsetOverride specifically for the test suite (with offset at 1 blocks need to include 2 relay chain headers which cannot be mocked atm)
* adds fast OpenGov for testnets

More info:
* https://github.com/galacticcouncil/polkadot-sdk/blob/fcda9c2d27456e4d1399446bef179100d280d0d0/docs/sdk/src/guides/handling_parachain_forks.rs#L53