### PR TITLE
chore: switch bootnode from dns to ipv4 due to domain cancellation

### DIFF
--- a/node/res/basilisk.json
+++ b/node/res/basilisk.json
@@ -6,7 +6,7 @@
     "/dns/p2p-01.basilisk.hydradx.io/tcp/30333/p2p/12D3KooWJRdTtgFnwrrcigrMRxdJ9zfmhtpH5qgAV9budWat4UtR",
     "/dns/p2p-02.basilisk.hydradx.io/tcp/30333/p2p/12D3KooWQNvuYebz6Zt34LnesFfdVh5i7FWP8GUe9QxuBmKE4b9R",
     "/dns/p2p-03.basilisk.hydradx.io/tcp/30333/p2p/12D3KooWD2Y9VkfC9cmQEpKZLN26xWq7XPJXHDUH8LNVmhoNBrdJ",
-    "/dns/bsxboot.sik.rocks/tcp/30333/p2p/12D3KooWAuiU9WhRyYjmsjhjrSLUUEUDeKxVRsj7xi2HVUmXLjSQ",
+    "/ip4/89.187.156.211/tcp/30333/p2p/12D3KooWAuiU9WhRyYjmsjhjrSLUUEUDeKxVRsj7xi2HVUmXLjSQ",
     "/ip4/89.187.156.216/tcp/30333/p2p/12D3KooWAjNQ57YTUJKAac4DypXauphotuDgZd2TEUpW1y8WP9x2",
     "/ip4/89.187.156.230/tcp/30333/p2p/12D3KooWDcFTGmMfF9opSyRrWenY1wk7NCo6ABbc4Y2i88iDR85o",
     "/ip4/146.59.47.189/tcp/30333/ws/p2p/12D3KooWH2KSkjiLRBfPwd8sxgGC6pVvquZSbznfvQYdTE4mRZQv"


### PR DESCRIPTION
Due to a 10x increase sadly the domain sik.rocks will be burried, therefore switching the bootnode record from dns to ip4.