### PR TITLE
fix: kill node when block production stops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basilisk"
-version = "23.0.0"
+version = "24.0.0"
 dependencies = [
  "basilisk-runtime",
  "clap",
@@ -5387,7 +5387,7 @@ dependencies = [
 [[package]]
 name = "hydra-dx-build-script-utils"
 version = "1.0.4"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "cargo-lock",
  "platforms",
@@ -5396,7 +5396,7 @@ dependencies = [
 [[package]]
 name = "hydra-dx-math"
 version = "13.2.1"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "fixed",
  "num-traits",
@@ -5412,7 +5412,7 @@ dependencies = [
 [[package]]
 name = "hydradx-traits"
 version = "4.7.1"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8180,7 +8180,7 @@ dependencies = [
 [[package]]
 name = "pallet-broadcast"
 version = "1.7.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -8237,7 +8237,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-rewards"
 version = "1.3.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8324,7 +8324,7 @@ dependencies = [
 [[package]]
 name = "pallet-currencies"
 version = "4.1.1"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8359,7 +8359,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.5.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8394,7 +8394,7 @@ dependencies = [
 [[package]]
 name = "pallet-duster"
 version = "3.8.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8632,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "pallet-liquidity-mining"
 version = "4.7.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft"
 version = "7.3.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8967,7 +8967,7 @@ dependencies = [
 [[package]]
 name = "pallet-relaychain-info"
 version = "0.4.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -9177,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.3.1"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9372,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-pause"
 version = "1.3.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11379,7 +11379,7 @@ dependencies = [
 [[package]]
 name = "primitives"
 version = "6.3.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -16372,7 +16372,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "1.2.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2e36f116d562fbf44cec62d40ef8e8b351b397ad"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
 dependencies = [
  "frame-system",
  "pretty_assertions",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilisk"
-version = "23.0.0"
+version = "24.0.0"
 description = "Basilisk node"
 authors = ["GalacticCouncil"]
 edition = "2021"


### PR DESCRIPTION
bump polkadot-sdk to include the following node fix: https://github.com/galacticcouncil/polkadot-sdk/commit/1a5051862c0feec96b62388d719c837de57ca24e

The node process will exit when block production stops, forcing a restart (if configured properly)