### PR TITLE
fix: node connectivity issue & temporary revert to 6s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basilisk"
-version = "25.0.0"
+version = "26.0.0"
 dependencies = [
  "basilisk-runtime",
  "clap",
@@ -1177,7 +1177,7 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-service",
- "primitives 6.7.1",
+ "primitives 6.7.2",
  "sc-basic-authorship",
  "sc-block-builder",
  "sc-chain-spec",
@@ -1258,7 +1258,7 @@ dependencies = [
  "polkadot-parachain-primitives",
  "pretty_assertions",
  "primitive-types 0.13.1",
- "primitives 6.7.1",
+ "primitives 6.7.2",
  "scale-info",
  "sp-core",
  "sp-io",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "basilisk-runtime"
-version = "134.0.0"
+version = "135.0.0"
 dependencies = [
  "basilisk-adapters",
  "basilisk-math",
@@ -1374,7 +1374,7 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-runtime-common",
  "primitive-types 0.13.1",
- "primitives 6.7.1",
+ "primitives 6.7.2",
  "scale-info",
  "serde",
  "smallvec",
@@ -8658,7 +8658,7 @@ dependencies = [
  "pallet-uniques",
  "parity-scale-codec",
  "pretty_assertions",
- "primitives 6.7.1",
+ "primitives 6.7.2",
  "scale-info",
  "serde",
  "sp-arithmetic",
@@ -9093,7 +9093,7 @@ dependencies = [
  "pallet-currencies",
  "parity-scale-codec",
  "pretty_assertions",
- "primitives 6.7.1",
+ "primitives 6.7.2",
  "scale-info",
  "serde",
  "sp-core",
@@ -9359,7 +9359,7 @@ dependencies = [
  "pallet-utility",
  "pallet-xyk",
  "parity-scale-codec",
- "primitives 6.7.1",
+ "primitives 6.7.2",
  "scale-info",
  "sp-api",
  "sp-core",
@@ -9605,7 +9605,7 @@ dependencies = [
  "pallet-xyk",
  "parity-scale-codec",
  "pretty_assertions",
- "primitives 6.7.1",
+ "primitives 6.7.2",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
@@ -9634,7 +9634,7 @@ dependencies = [
  "pallet-xyk",
  "pallet-xyk-liquidity-mining",
  "parity-scale-codec",
- "primitives 6.7.1",
+ "primitives 6.7.2",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
@@ -11394,7 +11394,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "6.7.1"
+version = "6.7.2"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -12413,7 +12413,7 @@ dependencies = [
  "polkadot-runtime-parachains",
  "polkadot-service",
  "pretty_assertions",
- "primitives 6.7.1",
+ "primitives 6.7.2",
  "rococo-runtime",
  "sc-consensus-grandpa",
  "sp-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "hash-db",
  "log",
@@ -1681,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2467,7 +2467,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -2493,7 +2493,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.24.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2612,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2703,7 +2703,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.25.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2761,7 +2761,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2777,7 +2777,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.21.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -2815,7 +2815,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -2826,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2841,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.21.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "approx",
  "bounded-collections",
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2876,7 +2876,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2893,7 +2893,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.19.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2917,7 +2917,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.13.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2954,7 +2954,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.25.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -2999,7 +2999,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3019,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.25.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.24.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
@@ -3110,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3869,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "alloy-core",
 ]
@@ -4215,7 +4215,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4282,7 +4282,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "41.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "49.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -4396,7 +4396,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.9.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -4482,7 +4482,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -4496,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "34.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -4569,7 +4569,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4622,7 +4622,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.47.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5387,7 +5387,7 @@ dependencies = [
 [[package]]
 name = "hydra-dx-build-script-utils"
 version = "1.0.4"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "cargo-lock",
  "platforms",
@@ -5396,7 +5396,7 @@ dependencies = [
 [[package]]
 name = "hydra-dx-math"
 version = "13.2.1"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "fixed",
  "num-traits",
@@ -5412,7 +5412,7 @@ dependencies = [
 [[package]]
 name = "hydradx-traits"
 version = "4.7.1"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7138,7 +7138,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "46.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "log",
@@ -7157,7 +7157,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7924,7 +7924,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7942,7 +7942,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7981,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "43.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "ethereum-standards",
  "frame-benchmarking",
@@ -8015,7 +8015,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8031,7 +8031,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8046,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8059,7 +8059,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8082,7 +8082,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "aquamarine",
  "docify",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8119,7 +8119,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8138,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -8163,7 +8163,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8180,7 +8180,7 @@ dependencies = [
 [[package]]
 name = "pallet-broadcast"
 version = "1.7.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -8201,7 +8201,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8219,7 +8219,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8237,7 +8237,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-rewards"
 version = "1.3.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8291,7 +8291,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8308,7 +8308,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "41.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8324,7 +8324,7 @@ dependencies = [
 [[package]]
 name = "pallet-currencies"
 version = "4.1.1"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8344,7 +8344,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "8.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8359,7 +8359,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.5.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8377,7 +8377,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8394,7 +8394,7 @@ dependencies = [
 [[package]]
 name = "pallet-duster"
 version = "3.8.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8434,7 +8434,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8447,7 +8447,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8515,7 +8515,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8533,7 +8533,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8555,7 +8555,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8571,7 +8571,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8590,7 +8590,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8632,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "pallet-liquidity-mining"
 version = "4.7.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8671,7 +8671,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "44.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.3.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "41.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8739,7 +8739,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft"
 version = "7.3.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8769,7 +8769,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8779,7 +8779,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8797,7 +8797,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8817,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8827,7 +8827,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8865,7 +8865,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.12.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8895,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8921,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "41.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8939,7 +8939,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8949,7 +8949,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8967,7 +8967,7 @@ dependencies = [
 [[package]]
 name = "pallet-relaychain-info"
 version = "0.4.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -8982,7 +8982,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.7.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.17",
@@ -9028,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.4.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.3.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9052,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.5.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9106,7 +9106,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9123,7 +9123,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9144,7 +9144,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9177,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.3.1"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9200,7 +9200,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9222,7 +9222,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9241,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9258,7 +9258,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "27.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9277,7 +9277,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "46.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9293,7 +9293,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9326,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9372,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-pause"
 version = "1.3.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9387,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9402,7 +9402,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "44.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9418,7 +9418,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9430,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9463,7 +9463,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9479,7 +9479,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.4.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9494,7 +9494,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9518,7 +9518,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "20.1.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9544,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9646,7 +9646,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9974,7 +9974,7 @@ checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9992,7 +9992,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "fatality",
  "futures",
@@ -10030,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "fatality",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -10087,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "24.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10110,7 +10110,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10121,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "fatality",
  "futures",
@@ -10143,7 +10143,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10157,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10201,7 +10201,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -10219,7 +10219,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -10251,7 +10251,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.7.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "futures",
@@ -10275,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bitvec",
  "futures",
@@ -10294,7 +10294,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10315,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10330,7 +10330,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "futures",
@@ -10352,7 +10352,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10366,7 +10366,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "fatality",
  "futures",
@@ -10400,7 +10400,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "futures",
@@ -10417,7 +10417,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "fatality",
  "futures",
@@ -10431,7 +10431,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10448,7 +10448,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -10476,7 +10476,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cpu-time",
  "futures",
@@ -10515,7 +10515,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -10530,7 +10530,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bs58",
  "futures",
@@ -10547,7 +10547,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "20.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -10605,7 +10605,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "derive_more 0.99.17",
@@ -10633,7 +10633,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "fatality",
  "futures",
@@ -10664,7 +10664,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "futures",
@@ -10684,7 +10684,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "17.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.17",
@@ -10700,7 +10700,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -10729,7 +10729,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10762,7 +10762,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10812,7 +10812,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -10824,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "20.0.3"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -10872,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.10.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10907,7 +10907,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -11015,7 +11015,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11379,7 +11379,7 @@ dependencies = [
 [[package]]
 name = "primitives"
 version = "6.3.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -12151,7 +12151,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -12249,7 +12249,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12742,7 +12742,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "32.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "log",
  "sp-core",
@@ -12753,7 +12753,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.51.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "futures",
@@ -12784,7 +12784,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "log",
@@ -12805,7 +12805,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.45.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12820,7 +12820,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "44.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "docify",
@@ -12846,7 +12846,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -12857,7 +12857,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.53.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -12899,7 +12899,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "fnv",
  "futures",
@@ -12925,7 +12925,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.47.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12953,7 +12953,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "futures",
@@ -12976,7 +12976,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "futures",
@@ -13005,7 +13005,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -13041,7 +13041,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13063,7 +13063,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "30.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13097,7 +13097,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "30.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13117,7 +13117,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -13130,7 +13130,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -13174,7 +13174,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -13194,7 +13194,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "futures",
@@ -13217,7 +13217,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13240,7 +13240,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.39.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "polkavm 0.24.0",
  "sc-allocator",
@@ -13253,7 +13253,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.36.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "log",
  "polkavm 0.24.0",
@@ -13264,7 +13264,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.39.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "anyhow",
  "log",
@@ -13280,7 +13280,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "console",
  "futures",
@@ -13296,7 +13296,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "36.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -13310,7 +13310,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.4",
@@ -13338,7 +13338,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.51.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13388,7 +13388,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.49.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -13398,7 +13398,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "ahash",
  "futures",
@@ -13417,7 +13417,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13438,7 +13438,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13473,7 +13473,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13492,7 +13492,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.17.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bs58",
  "bytes",
@@ -13513,7 +13513,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "46.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bytes",
  "fnv",
@@ -13547,7 +13547,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -13556,7 +13556,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "46.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -13588,7 +13588,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.50.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13608,7 +13608,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -13632,7 +13632,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "futures",
@@ -13665,7 +13665,7 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.3.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
@@ -13680,7 +13680,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.52.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "directories",
@@ -13744,7 +13744,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.39.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13755,7 +13755,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.25.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "clap",
  "fs4",
@@ -13768,7 +13768,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.51.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13787,7 +13787,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "43.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "derive_more 0.99.17",
  "futures",
@@ -13807,7 +13807,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "29.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "chrono",
  "futures",
@@ -13826,7 +13826,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "40.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "chrono",
  "console",
@@ -13856,7 +13856,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -13867,7 +13867,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "40.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "futures",
@@ -13898,7 +13898,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "futures",
@@ -13915,7 +13915,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -14581,7 +14581,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "18.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -14905,7 +14905,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "hash-db",
@@ -14927,7 +14927,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "23.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14941,7 +14941,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "41.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14953,7 +14953,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "27.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -14967,7 +14967,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14979,7 +14979,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -14989,7 +14989,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -15010,7 +15010,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "futures",
@@ -15024,7 +15024,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15040,7 +15040,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15058,7 +15058,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "25.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15078,7 +15078,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "24.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -15095,7 +15095,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15106,7 +15106,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -15168,7 +15168,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -15181,7 +15181,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch)",
@@ -15191,7 +15191,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -15200,7 +15200,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15210,7 +15210,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -15220,7 +15220,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.18.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15232,7 +15232,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -15245,7 +15245,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "41.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bytes",
  "docify",
@@ -15271,7 +15271,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -15281,7 +15281,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.43.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -15292,7 +15292,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -15301,7 +15301,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.11.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-metadata 23.0.1",
  "parity-scale-codec",
@@ -15311,7 +15311,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15322,7 +15322,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15339,7 +15339,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15352,7 +15352,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -15362,7 +15362,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "backtrace",
  "regex",
@@ -15371,7 +15371,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "35.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -15381,7 +15381,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "42.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -15410,7 +15410,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "30.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -15429,7 +15429,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "19.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "Inflector",
  "expander",
@@ -15442,7 +15442,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15456,7 +15456,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "39.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -15469,7 +15469,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.46.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "hash-db",
  "log",
@@ -15489,7 +15489,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "21.2.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -15513,12 +15513,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15530,7 +15530,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15542,7 +15542,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15553,7 +15553,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -15562,7 +15562,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "37.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15576,7 +15576,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "40.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "ahash",
  "foldhash 0.1.5",
@@ -15601,7 +15601,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "40.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15618,7 +15618,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -15630,7 +15630,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "22.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15642,7 +15642,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "32.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -15708,7 +15708,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.21.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -15721,7 +15721,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "17.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -15742,7 +15742,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "21.1.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "environmental",
  "frame-support",
@@ -15766,7 +15766,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "20.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15877,7 +15877,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -15902,12 +15902,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "45.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -15927,7 +15927,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.6"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "http-body-util",
  "hyper 1.5.1",
@@ -15941,7 +15941,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "44.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15958,7 +15958,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "27.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -16372,7 +16372,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "1.2.0"
-source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#ac0941d654aaf4eec06e9a54794875464f259e28"
+source = "git+https://github.com/galacticcouncil/hydration-node?branch=polkadot-stable2506-11-snek#2ac74b9856cd26ae917838bebeb53bec223b8012"
 dependencies = [
  "frame-system",
  "pretty_assertions",
@@ -16783,7 +16783,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "20.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -16794,7 +16794,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "expander",
  "proc-macro-crate 3.1.0",
@@ -17676,7 +17676,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "24.0.1"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -17783,7 +17783,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -18393,7 +18393,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.20.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -18427,7 +18427,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -18438,7 +18438,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.8.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -18452,7 +18452,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "21.0.0"
-source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#1a5051862c0feec96b62388d719c837de57ca24e"
+source = "git+https://github.com/galacticcouncil/polkadot-sdk?branch=polkadot-stable2506-11-patch#d5547f7415adf75b779c3f544143f1268bd0c90a"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilisk"
-version = "25.0.0"
+version = "26.0.0"
 description = "Basilisk node"
 authors = ["GalacticCouncil"]
 edition = "2021"

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -436,7 +436,7 @@ fn start_consensus(
 		para_id,
 		proposer,
 		collator_service,
-		authoring_duration: Duration::from_millis(2000),
+		authoring_duration: Duration::from_millis(1500),
 		reinitialize: false,
 		slot_offset: Duration::from_secs(1),
 		block_import_handle,

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitives"
-version = "6.7.1"
+version = "6.7.2"
 authors = ["GalacticCouncil"]
 edition = "2021"
 repository = "https://github.com/galacticcouncil/Basilisk-node"

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -44,7 +44,7 @@ pub mod time {
 	/// up by `pallet_aura` to implement `fn slot_duration()`.
 	///
 	/// Change this to adjust the block time.
-	pub const MILLISECS_PER_BLOCK: u64 = 2000;
+	pub const MILLISECS_PER_BLOCK: u64 = 6000;
 
 	// The slot duration determines the length of each author's turn and is decoupled from the block
 	// production interval. During their slot, authors are allowed to produce multiple blocks. **The
@@ -79,9 +79,9 @@ pub mod chain {
 	/// Minimum pool liquidity
 	pub const MIN_POOL_LIQUIDITY: Balance = 1000;
 
-	/// We allow for 1.5 seconds of compute with a 2 second average block.
+	/// We allow for 2 seconds of compute with a 6 second average block.
 	pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
-		WEIGHT_REF_TIME_PER_SECOND.saturating_mul(3).saturating_div(2),
+		WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),
 		polkadot_primitives::v8::MAX_POV_SIZE as u64,
 	);
 
@@ -100,10 +100,10 @@ mod tests {
 		assert_eq!(DAYS / 24, HOURS);
 		// 60 minuts in an hour
 		assert_eq!(HOURS / 60, MINUTES);
-		// 1 minute = 60s = 10 blocks 2s each
-		assert_eq!(MINUTES, 30);
-		// 2s per block
-		assert_eq!(SECS_PER_BLOCK, 2);
+		// 1 minute = 60s = 10 blocks 6s each
+		assert_eq!(MINUTES, 10);
+		// 6s per block
+		assert_eq!(SECS_PER_BLOCK, 6);
 		// 1s = 1000ms
 		assert_eq!(MILLISECS_PER_BLOCK / 1000, SECS_PER_BLOCK);
 		// Extra check for epoch time because changing it bricks the block production and requires regenesis

--- a/runtime/basilisk/Cargo.toml
+++ b/runtime/basilisk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basilisk-runtime"
-version = "134.0.0"
+version = "135.0.0"
 authors = ["GalacticCouncil"]
 edition = "2021"
 homepage = "https://github.com/galacticcouncil/Basilisk-node"

--- a/runtime/basilisk/src/lib.rs
+++ b/runtime/basilisk/src/lib.rs
@@ -103,7 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("basilisk"),
 	impl_name: Cow::Borrowed("basilisk"),
 	authoring_version: 1,
-	spec_version: 134,
+	spec_version: 135,
 	impl_version: 0,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/basilisk/src/system.rs
+++ b/runtime/basilisk/src/system.rs
@@ -61,7 +61,7 @@ pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 pub const DEFAULT_RELAY_PARENT_OFFSET: u32 = 1;
 /// How many parachain blocks are processed by the relay chain per parent. Limits the number of
 /// blocks authored per slot.
-pub const BLOCK_PROCESSING_VELOCITY: u32 = 3;
+pub const BLOCK_PROCESSING_VELOCITY: u32 = 1;
 /// Maximum number of blocks simultaneously accepted by the Runtime, not yet included into the
 /// relay chain.
 pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = (3 + DEFAULT_RELAY_PARENT_OFFSET) * BLOCK_PROCESSING_VELOCITY;
@@ -242,7 +242,7 @@ impl pallet_timestamp::Config for Runtime {
 	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = u64;
 	type OnTimestampSet = ();
-	type MinimumPeriod = ConstU64<0>;
+	type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
 	type WeightInfo = weights::pallet_timestamp::BasiliskWeight<Runtime>;
 }
 
@@ -515,7 +515,7 @@ impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type MaxAuthorities = MaxAuthorities;
 	type DisabledValidators = ();
-	type AllowMultipleBlocksPerSlot = ConstBool<true>;
+	type AllowMultipleBlocksPerSlot = ConstBool<false>;
 	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 


### PR DESCRIPTION
This PR bumps polkadot-sdk to include [several backports](https://github.com/galacticcouncil/polkadot-sdk/pull/16) that should help resolve the connectivity issues between collators and relay chain validators

Also, it temporarily restores 6s blocktime to verify the fix